### PR TITLE
feat: Core 型定義 + ToolRegistry 実装

### DIFF
--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,0 +1,36 @@
+/**
+ * サブエージェントのステータス
+ */
+export type SubAgentStatus = 'running' | 'completed' | 'failed'
+
+/** サブエージェントのハンドル */
+export interface SubAgentHandle {
+  readonly id: string
+  readonly status: SubAgentStatus
+  readonly result?: unknown
+}
+
+/** エージェント設定 */
+export interface AgentConfig {
+  readonly persona: string
+  readonly skills: readonly string[]
+  readonly provider: string
+  readonly model: string
+  readonly task: string
+}
+
+/**
+ * サブエージェントランナーインターフェース
+ *
+ * Worker Threads を使用してサブエージェントを並列実行する。
+ */
+export interface SubAgentRunner {
+  /** サブエージェントを生成する */
+  spawn(config: AgentConfig): Promise<SubAgentHandle>
+
+  /** 実行中のサブエージェント一覧を取得する */
+  list(): SubAgentHandle[]
+
+  /** サブエージェントを停止する */
+  stop(id: string): Promise<void>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,23 @@
 export const VERSION = '0.1.0' as const
+
+// Result
+export type { Result } from './result.js'
+export { ok, err } from './result.js'
+
+// LLM Provider types
+export type {
+  JsonSchema,
+  Message,
+  Tool,
+  ToolCall,
+  TokenUsage,
+  LLMResponse,
+  LLMProvider,
+} from './providers/types.js'
+
+// Tool types + ToolRegistry
+export type { ToolResult, ToolDefinition } from './tools/types.js'
+export { ToolRegistry } from './tools/types.js'
+
+// Agent types
+export type { SubAgentStatus, SubAgentHandle, AgentConfig, SubAgentRunner } from './agent/types.js'

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,55 @@
+import type { Result } from '../result.js'
+
+/**
+ * JSON Schema を表す型エイリアス
+ *
+ * 将来的に Zod スキーマ等への置換を想定し、
+ * Record<string, unknown> に別名を付けて可読性を確保する。
+ */
+export type JsonSchema = Record<string, unknown>
+
+/** LLM メッセージ */
+export interface Message {
+  readonly role: 'user' | 'assistant' | 'system'
+  readonly content: string
+}
+
+/** LLM に渡すツール定義 */
+export interface Tool {
+  readonly name: string
+  readonly description: string
+  readonly parameters: JsonSchema
+}
+
+/** LLM が返すツール呼び出し */
+export interface ToolCall {
+  readonly id: string
+  readonly name: string
+  readonly arguments: Record<string, unknown>
+}
+
+/** トークン使用量 */
+export interface TokenUsage {
+  readonly inputTokens: number
+  readonly outputTokens: number
+}
+
+/** LLM レスポンス */
+export interface LLMResponse {
+  readonly content: string
+  readonly toolCalls?: readonly ToolCall[]
+  readonly usage?: TokenUsage
+}
+
+/**
+ * LLM プロバイダーインターフェース
+ *
+ * Claude, OpenAI, Ollama, Gemini の4プロバイダーが実装する。
+ */
+export interface LLMProvider {
+  /** 同期的にメッセージを送信し、レスポンスを取得する */
+  complete(messages: readonly Message[], tools?: readonly Tool[]): Promise<Result<LLMResponse>>
+
+  /** ストリーミングでレスポンスを取得する（オプション） */
+  stream?(messages: readonly Message[], tools?: readonly Tool[]): AsyncIterable<string>
+}

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,0 +1,19 @@
+/**
+ * 共通 Result 型
+ *
+ * 例外スローの代わりに成功/失敗を型安全に表現する。
+ * CLAUDE.md の Result パターンに準拠。
+ */
+export type Result<T, E = string> =
+  | { readonly ok: true; readonly data: T }
+  | { readonly ok: false; readonly error: E }
+
+/** 成功 Result を生成する */
+export function ok<T>(data: T): Result<T, never> {
+  return { ok: true, data }
+}
+
+/** 失敗 Result を生成する */
+export function err<E = string>(error: E): Result<never, E> {
+  return { ok: false, error }
+}

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,0 +1,67 @@
+import type { Result } from '../result.js'
+import { ok, err } from '../result.js'
+import type { JsonSchema } from '../providers/types.js'
+
+/** ツール実行結果 */
+export interface ToolResult {
+  readonly ok: boolean
+  readonly output: string
+  readonly error?: string
+}
+
+/**
+ * ツール定義インターフェース
+ *
+ * 組み込みツール（read/write/shell/grep）と MCP ツールの両方が実装する。
+ */
+export interface ToolDefinition {
+  readonly name: string
+  readonly description: string
+  readonly parameters: JsonSchema
+  execute(args: Record<string, unknown>): Promise<ToolResult>
+}
+
+/**
+ * ToolRegistry — 組み込みツールと MCP ツールを統合管理する
+ *
+ * - register(): ビルトインツールを登録
+ * - registerMcp(): MCP 経由ツールを登録
+ * - get(): 名前でツールを検索（ビルトイン優先）
+ * - list(): 全ツールをマージして返す（ビルトインが MCP を上書き）
+ */
+export class ToolRegistry {
+  private readonly builtins: Map<string, ToolDefinition> = new Map()
+  private readonly mcpTools: Map<string, ToolDefinition> = new Map()
+
+  /** ビルトインツールを登録する。重複時は Result エラーを返す。 */
+  register(tool: ToolDefinition): Result<void> {
+    if (this.builtins.has(tool.name)) {
+      return err(`Builtin tool already registered: ${tool.name}`)
+    }
+    this.builtins.set(tool.name, tool)
+    return ok(undefined)
+  }
+
+  /** MCP ツールを登録する。重複時は Result エラーを返す。 */
+  registerMcp(tool: ToolDefinition): Result<void> {
+    if (this.mcpTools.has(tool.name)) {
+      return err(`MCP tool already registered: ${tool.name}`)
+    }
+    this.mcpTools.set(tool.name, tool)
+    return ok(undefined)
+  }
+
+  /** 名前でツールを取得する。ビルトイン → MCP の優先順位。 */
+  get(name: string): ToolDefinition | undefined {
+    return this.builtins.get(name) ?? this.mcpTools.get(name)
+  }
+
+  /** 全ツールをマージして返す。名前衝突時はビルトインが優先。 */
+  list(): ToolDefinition[] {
+    const merged = new Map<string, ToolDefinition>(this.mcpTools)
+    for (const [name, tool] of this.builtins) {
+      merged.set(name, tool)
+    }
+    return [...merged.values()]
+  }
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,8 +1,84 @@
 import { describe, it, expect } from 'vitest'
-import { VERSION } from '../src/index.js'
+import { VERSION, ok, err, ToolRegistry } from '../src/index.js'
+import type {
+  Result,
+  JsonSchema,
+  Message,
+  Tool,
+  ToolCall,
+  TokenUsage,
+  LLMResponse,
+  LLMProvider,
+  ToolResult,
+  ToolDefinition,
+  SubAgentStatus,
+  SubAgentHandle,
+  AgentConfig,
+  SubAgentRunner,
+} from '../src/index.js'
 
 describe('wn-core', () => {
   it('バージョンが定義されている', () => {
     expect(VERSION).toBe('0.1.0')
+  })
+
+  it('ok/err ヘルパーがエクスポートされている', () => {
+    expect(typeof ok).toBe('function')
+    expect(typeof err).toBe('function')
+  })
+
+  it('ToolRegistry クラスがエクスポートされている', () => {
+    expect(typeof ToolRegistry).toBe('function')
+    const registry = new ToolRegistry()
+    expect(registry).toBeInstanceOf(ToolRegistry)
+  })
+
+  it('型エクスポートがコンパイル時に利用可能（型チェック用）', () => {
+    // これらの型が import できること自体がテスト
+    // 実行時には値を生成して検証する
+    const message: Message = { role: 'user', content: 'hello' }
+    expect(message.role).toBe('user')
+
+    const result: Result<number> = ok(42)
+    expect(result.ok).toBe(true)
+
+    const schema: JsonSchema = { type: 'object' }
+    expect(schema).toBeDefined()
+
+    const tool: Tool = { name: 'test', description: 'test tool', parameters: {} }
+    expect(tool.name).toBe('test')
+
+    const toolCall: ToolCall = { id: '1', name: 'test', arguments: {} }
+    expect(toolCall.id).toBe('1')
+
+    const usage: TokenUsage = { inputTokens: 10, outputTokens: 20 }
+    expect(usage.inputTokens).toBe(10)
+
+    const response: LLMResponse = { content: 'hello' }
+    expect(response.content).toBe('hello')
+
+    const toolResult: ToolResult = { ok: true, output: 'done' }
+    expect(toolResult.ok).toBe(true)
+
+    const status: SubAgentStatus = 'running'
+    expect(status).toBe('running')
+
+    const handle: SubAgentHandle = { id: '1', status: 'running' }
+    expect(handle.id).toBe('1')
+
+    const config: AgentConfig = {
+      persona: 'default',
+      skills: [],
+      provider: 'claude',
+      model: 'sonnet',
+      task: 'test',
+    }
+    expect(config.persona).toBe('default')
+
+    // LLMProvider, ToolDefinition, SubAgentRunner はインターフェースのため
+    // ここではインポートできること自体が型チェックの検証
+    expect(undefined as LLMProvider | undefined).toBeUndefined()
+    expect(undefined as ToolDefinition | undefined).toBeUndefined()
+    expect(undefined as SubAgentRunner | undefined).toBeUndefined()
   })
 })

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { ok, err } from '../src/result.js'
+import type { Result } from '../src/result.js'
+
+describe('Result', () => {
+  describe('ok()', () => {
+    it('ok: true と data を持つオブジェクトを返す', () => {
+      const result = ok(42)
+      expect(result).toStrictEqual({ ok: true, data: 42 })
+    })
+
+    it('data に任意の型を格納できる', () => {
+      const result = ok({ name: 'test', values: [1, 2, 3] })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toStrictEqual({ name: 'test', values: [1, 2, 3] })
+      }
+    })
+
+    it('data に undefined を格納できる', () => {
+      const result = ok(undefined)
+      expect(result).toStrictEqual({ ok: true, data: undefined })
+    })
+  })
+
+  describe('err()', () => {
+    it('ok: false と error を持つオブジェクトを返す', () => {
+      const result = err('something went wrong')
+      expect(result).toStrictEqual({ ok: false, error: 'something went wrong' })
+    })
+
+    it('カスタムエラー型を使用できる', () => {
+      const result = err({ code: 404, message: 'not found' })
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toStrictEqual({ code: 404, message: 'not found' })
+      }
+    })
+  })
+
+  describe('型の絞り込み', () => {
+    it('ok チェックで data にアクセスでき、error にはアクセスできない', () => {
+      const result: Result<number> = ok(42)
+      if (result.ok) {
+        // result.data にアクセスできる（型エラーなし）
+        expect(result.data).toBe(42)
+      } else {
+        // result.error にアクセスできる（型エラーなし）
+        expect(result.error).toBeTypeOf('string')
+      }
+    })
+  })
+})

--- a/tests/tools/tool-registry.test.ts
+++ b/tests/tools/tool-registry.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ToolRegistry } from '../../src/tools/types.js'
+import type { ToolDefinition, ToolResult } from '../../src/tools/types.js'
+
+/** テスト用のダミーツールを生成する */
+function createDummyTool(name: string, description = `${name} tool`): ToolDefinition {
+  return {
+    name,
+    description,
+    parameters: {},
+    execute: (): Promise<ToolResult> =>
+      Promise.resolve({
+        ok: true,
+        output: `${name} executed`,
+      }),
+  }
+}
+
+describe('ToolRegistry', () => {
+  let registry: ToolRegistry
+
+  beforeEach(() => {
+    registry = new ToolRegistry()
+  })
+
+  describe('register()', () => {
+    it('ビルトインツールを登録できる', () => {
+      const tool = createDummyTool('read')
+      const result = registry.register(tool)
+      expect(result.ok).toBe(true)
+    })
+
+    it('同名のビルトインツールを重複登録するとエラーを返す', () => {
+      const tool = createDummyTool('read')
+      registry.register(tool)
+      const result = registry.register(tool)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toContain('read')
+      }
+    })
+  })
+
+  describe('registerMcp()', () => {
+    it('MCP ツールを登録できる', () => {
+      const tool = createDummyTool('mcp-scan')
+      const result = registry.registerMcp(tool)
+      expect(result.ok).toBe(true)
+    })
+
+    it('同名の MCP ツールを重複登録するとエラーを返す', () => {
+      const tool = createDummyTool('mcp-scan')
+      registry.registerMcp(tool)
+      const result = registry.registerMcp(tool)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toContain('mcp-scan')
+      }
+    })
+  })
+
+  describe('get()', () => {
+    it('ビルトインツールを名前で取得できる', () => {
+      const tool = createDummyTool('read')
+      registry.register(tool)
+      const found = registry.get('read')
+      expect(found).toBeDefined()
+      expect(found?.name).toBe('read')
+    })
+
+    it('MCP ツールを名前で取得できる', () => {
+      const tool = createDummyTool('mcp-scan')
+      registry.registerMcp(tool)
+      const found = registry.get('mcp-scan')
+      expect(found).toBeDefined()
+      expect(found?.name).toBe('mcp-scan')
+    })
+
+    it('同名のビルトインと MCP がある場合、ビルトインが優先される', () => {
+      const builtin = createDummyTool('overlap', 'builtin version')
+      const mcp = createDummyTool('overlap', 'mcp version')
+      registry.register(builtin)
+      registry.registerMcp(mcp)
+      const found = registry.get('overlap')
+      expect(found).toBeDefined()
+      expect(found?.description).toBe('builtin version')
+    })
+
+    it('未登録のツール名に対して undefined を返す', () => {
+      const found = registry.get('nonexistent')
+      expect(found).toBeUndefined()
+    })
+
+    it('空のレジストリで undefined を返す', () => {
+      const found = registry.get('anything')
+      expect(found).toBeUndefined()
+    })
+  })
+
+  describe('list()', () => {
+    it('空のレジストリで空配列を返す', () => {
+      const tools = registry.list()
+      expect(tools).toStrictEqual([])
+    })
+
+    it('ビルトインツールのみ登録した場合、それらを返す', () => {
+      registry.register(createDummyTool('read'))
+      registry.register(createDummyTool('write'))
+      const tools = registry.list()
+      expect(tools).toHaveLength(2)
+      const names = tools.map((t) => t.name)
+      expect(names).toContain('read')
+      expect(names).toContain('write')
+    })
+
+    it('MCP ツールのみ登録した場合、それらを返す', () => {
+      registry.registerMcp(createDummyTool('mcp-a'))
+      registry.registerMcp(createDummyTool('mcp-b'))
+      const tools = registry.list()
+      expect(tools).toHaveLength(2)
+      const names = tools.map((t) => t.name)
+      expect(names).toContain('mcp-a')
+      expect(names).toContain('mcp-b')
+    })
+
+    it('ビルトインと MCP をマージして返す', () => {
+      registry.register(createDummyTool('read'))
+      registry.registerMcp(createDummyTool('mcp-scan'))
+      const tools = registry.list()
+      expect(tools).toHaveLength(2)
+      const names = tools.map((t) => t.name)
+      expect(names).toContain('read')
+      expect(names).toContain('mcp-scan')
+    })
+
+    it('名前が衝突した場合、ビルトインが MCP を上書きする', () => {
+      const builtin = createDummyTool('overlap', 'builtin version')
+      const mcp = createDummyTool('overlap', 'mcp version')
+      registry.register(builtin)
+      registry.registerMcp(mcp)
+      const tools = registry.list()
+      expect(tools).toHaveLength(1)
+      expect(tools[0]?.description).toBe('builtin version')
+    })
+
+    it('複数の衝突がある場合も正しくマージされる', () => {
+      // ビルトイン 2 つ + MCP 3 つ（うち 2 つが衝突）
+      registry.register(createDummyTool('read', 'builtin-read'))
+      registry.register(createDummyTool('write', 'builtin-write'))
+      registry.registerMcp(createDummyTool('read', 'mcp-read'))
+      registry.registerMcp(createDummyTool('write', 'mcp-write'))
+      registry.registerMcp(createDummyTool('mcp-only', 'mcp-only'))
+      const tools = registry.list()
+      expect(tools).toHaveLength(3)
+      const map = new Map(tools.map((t) => [t.name, t.description]))
+      expect(map.get('read')).toBe('builtin-read')
+      expect(map.get('write')).toBe('builtin-write')
+      expect(map.get('mcp-only')).toBe('mcp-only')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `Result<T,E>` 型と `ok()`/`err()` ヘルパーを `src/result.ts` に実装（例外フリーのエラーハンドリング）
- LLM プロバイダーインターフェース群を `src/providers/types.ts` に定義（Message, Tool, ToolCall, TokenUsage, LLMResponse, LLMProvider）
- エージェントインターフェース群を `src/agent/types.ts` に定義（AgentConfig, SubAgentHandle, SubAgentRunner）
- `ToolDefinition` インターフェースと `ToolRegistry` クラスを `src/tools/types.ts` に実装（builtin/MCP 優先順位付き統合管理）
- `src/index.ts` から全型・クラス・関数を re-export

## Test plan

- [x] Result ヘルパーのテスト（6件）— `tests/result.test.ts`
- [x] ToolRegistry のテスト（15件）— `tests/tools/tool-registry.test.ts`
- [x] re-export の検証テスト（4件）— `tests/index.test.ts`
- [x] `npm test` → 全25テスト通過
- [x] `npm run typecheck` → 型エラーなし
- [x] `npm run build` → ビルド成功
- [x] `npm run lint` → ESLint エラーなし
- [x] `npm run format:check` → フォーマット統一

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)