### PR TITLE
feat: implement Loader layer (config/persona/skill/agent)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,5 +137,5 @@ weness、小さなAI-AgentCore weave（編む）+ harness（馬具・制御）�
 ---
 
 ## Document
-
+planで実装計画を考えた場合は以下に記載
 ドキュメントは `/docs` に記載

--- a/docs/plan-loader.md
+++ b/docs/plan-loader.md
@@ -1,0 +1,119 @@
+# 計画: Loader 層実装（config / persona / skill / agent）
+
+## コンテキスト
+
+組み込みツール（Issue #5 / PR #6）が完了。ロードマップ B として、architecture.md §5.2, §5.4, §6 で定義された **Loader 層** を実装する。設定ファイル（config.json）と 3 層リソース（persona / skill / agent）を階層的に読み込み、マージする機能を提供する。
+
+## 設計判断
+
+1. **関数パターン** — 各ローダーは `loadXxx()` 関数で Result を返す（クラス不要）
+2. **frontmatter パーサー** — 外部依存なし。簡易 YAML（flat key-value + inline array）のみサポート
+3. **deep merge** — config.json はオブジェクト再帰マージ、配列は上書き（マージしない）
+4. **環境変数置換** — `${VAR_NAME}` → `process.env[VAR_NAME]`、未定義は元文字列を保持
+5. **LoaderError 構造体** — code + message + path でエラーを構造化
+6. **ENOENT 許容** — ディレクトリ/ファイル不在は正常（空の結果を返す）、パースエラーのみ err
+
+## 変更対象ファイル
+
+新規作成（11ファイル）:
+
+| ファイル | 内容 |
+|---------|------|
+| `src/loader/types.ts` | WnConfig, Persona, Skill, AgentDef, LoaderError, FrontmatterResult |
+| `src/loader/frontmatter.ts` | `parseFrontmatter()` — 簡易 YAML frontmatter パーサー |
+| `src/loader/config-loader.ts` | `loadConfig()` — JSON 読み込み + deep merge + env var 置換 |
+| `src/loader/persona-loader.ts` | `loadPersonas()` — .md ファイルから persona 読み込み |
+| `src/loader/skill-loader.ts` | `loadSkills()` — SKILL.md の frontmatter + body 読み込み |
+| `src/loader/agent-loader.ts` | `loadAgents()` — agent .md の frontmatter + body 読み込み |
+| `tests/loader/frontmatter.test.ts` | frontmatter パーサーのテスト（13件） |
+| `tests/loader/config-loader.test.ts` | config ローダーのテスト（19件） |
+| `tests/loader/persona-loader.test.ts` | persona ローダーのテスト（8件） |
+| `tests/loader/skill-loader.test.ts` | skill ローダーのテスト（8件） |
+| `tests/loader/agent-loader.test.ts` | agent ローダーのテスト（7件） |
+
+変更（2ファイル）:
+- `src/index.ts` — Loader 型・関数を re-export
+- `tests/index.test.ts` — re-export の検証追加
+
+## 型定義（`src/loader/types.ts`）
+
+```typescript
+interface WnConfig {
+  defaultProvider: string    // デフォルト: "claude"
+  defaultModel: string       // デフォルト: "claude-sonnet-4-20250514"
+  defaultPersona: string     // デフォルト: "default"
+  providers: Record<string, ProviderConfig>
+  mcp?: McpConfig
+}
+
+interface ProviderConfig { apiKey?: string; baseUrl?: string }
+interface McpConfig { servers: McpServerConfig[] }
+interface McpServerConfig { name: string; command: string; args: string[] }
+
+interface Persona { name: string; content: string }
+interface Skill { name: string; description: string; tools: string[]; body: string }
+interface AgentDef { name: string; persona: string; skills: string[]; provider: string; model: string; description: string }
+
+interface FrontmatterResult { attributes: Record<string, string | string[]>; body: string }
+interface LoaderError { code: LoaderErrorCode; message: string; path?: string }
+type LoaderErrorCode = 'FILE_NOT_FOUND' | 'PARSE_ERROR' | 'VALIDATION_ERROR' | 'IO_ERROR'
+```
+
+## 実装ステップ（TDD）
+
+### Step 1: types.ts（テスト不要、純粋な型定義）
+
+### Step 2: frontmatter パーサー（13テスト）
+
+- frontmatter 付き文字列からキー・値とボディを抽出する
+- インライン配列を string[] としてパースする
+- frontmatter がない場合、全体をボディとして返す
+- 空の frontmatter を正しく扱う
+- ボディが空の場合、空文字列を返す
+- コメント行・空行を無視する
+- 値の前後空白をトリムする
+- キーにハイフンを含む場合を正しくパースする
+- 空の配列 [] を空配列として返す
+- 配列内要素の前後空白をトリムする
+- Windows 改行コード（CRLF）を正しく扱う
+- 開始デリミタがあるが終了デリミタがない場合にエラーを返す
+
+### Step 3: config ローダー（19テスト）
+
+- JSON 読み込み: global読み込み / local上書き / 不在時デフォルト / 不正JSON / ディレクトリ不在
+- deep merge: 再帰マージ / local上書き / 配列上書き / 新プロパティ追加
+- CLI オーバーライド: 3フィールド上書き / undefined スキップ
+- 環境変数: 置換 / 未定義保持 / ネスト内 / 配列内 / 非文字列スキップ / 複数変数
+- デフォルト値: provider / model / providers
+
+### Step 4: persona ローダー（8テスト）
+
+- グローバルから .md 読み込み / ファイル名→persona名 / 全文→content
+- ローカルが同名を上書き / 異名はマージ
+- ディレクトリ不在→空Map / .md以外無視 / 空ディレクトリ→空Map
+
+### Step 5: skill ローダー（8テスト）
+
+- SKILL.md から name/description/tools 抽出 / body 取得
+- ローカル上書き / 異名マージ / ディレクトリ不在→空Map
+- name 未指定→ディレクトリ名フォールバック / description 未指定→エラー / SKILL.md 不在→スキップ
+
+### Step 6: agent ローダー（7テスト）
+
+- frontmatter から全フィールド抽出 / body→description
+- ローカル上書き / 異名マージ / ディレクトリ不在→空Map
+- name 未指定→ファイル名フォールバック / .md以外無視
+
+### Step 7: index.ts 更新 + 全検証
+
+## セキュリティ考慮事項
+
+- パス操作: `path.resolve()` + `path.join()` で正規化
+- `as` キャスト禁止: `isNodeError()` 型ガードで ENOENT 判定
+- 環境変数: config.json に直接書かれた API キーは非推奨、`${VAR}` パターンを推奨
+- JSON パース: `JSON.parse()` の結果を `isPlainObject()` で型チェック
+
+## テスト結果
+
+- 全13ファイル、132テストがパス
+- 既存75件 + 新規57件

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,24 @@ export type { ShellConfig } from './tools/shell.js'
 
 // Agent types
 export type { SubAgentStatus, SubAgentHandle, AgentConfig, SubAgentRunner } from './agent/types.js'
+
+// Loader types
+export type {
+  WnConfig,
+  ProviderConfig,
+  McpConfig,
+  McpServerConfig,
+  Persona,
+  Skill,
+  AgentDef,
+  FrontmatterResult,
+  LoaderError,
+  LoaderErrorCode,
+} from './loader/types.js'
+
+// Loader functions
+export { parseFrontmatter } from './loader/frontmatter.js'
+export { loadConfig } from './loader/config-loader.js'
+export { loadPersonas } from './loader/persona-loader.js'
+export { loadSkills } from './loader/skill-loader.js'
+export { loadAgents } from './loader/agent-loader.js'

--- a/src/loader/agent-loader.ts
+++ b/src/loader/agent-loader.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { Result } from '../result.js'
+import { ok, err } from '../result.js'
+import type { AgentDef, LoaderError } from './types.js'
+import { parseFrontmatter } from './frontmatter.js'
+
+/**
+ * NodeJS.ErrnoException 型ガード
+ */
+function isNodeError(e: unknown): e is NodeJS.ErrnoException {
+  return e instanceof Error && 'code' in e
+}
+
+/**
+ * attributes から文字列値を安全に取得する。
+ * 値が string でなければ fallback を返す。
+ */
+function getString(
+  attrs: Readonly<Record<string, string | readonly string[]>>,
+  key: string,
+  fallback: string,
+): string {
+  const val = attrs[key]
+  return typeof val === 'string' ? val : fallback
+}
+
+/**
+ * attributes から文字列配列を安全に取得する。
+ * 値が配列でなければ空配列を返す。
+ */
+function getStringArray(
+  attrs: Readonly<Record<string, string | readonly string[]>>,
+  key: string,
+): readonly string[] {
+  const val = attrs[key]
+  if (Array.isArray(val)) {
+    const arr: readonly string[] = val
+    return arr
+  }
+  return []
+}
+
+/**
+ * 指定ディレクトリから .md ファイルを読み込み、AgentDef の Map を返す。
+ * ディレクトリが存在しない場合（ENOENT）は空 Map を返す。
+ */
+async function loadAgentsFromDir(dir: string): Promise<Result<Map<string, AgentDef>, LoaderError>> {
+  let entries: fs.Dirent[]
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true })
+  } catch (e: unknown) {
+    if (isNodeError(e) && e.code === 'ENOENT') {
+      return ok(new Map<string, AgentDef>())
+    }
+    return err({
+      code: 'IO_ERROR',
+      message: isNodeError(e) ? e.message : 'Unknown IO error',
+      path: dir,
+    })
+  }
+
+  const agents = new Map<string, AgentDef>()
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue
+    if (!entry.name.endsWith('.md')) continue
+
+    const fileBaseName = path.basename(entry.name, '.md')
+    const filePath = path.join(dir, entry.name)
+
+    let content: string
+    try {
+      content = await fs.promises.readFile(filePath, 'utf-8')
+    } catch (e: unknown) {
+      return err({
+        code: 'IO_ERROR',
+        message: isNodeError(e) ? e.message : 'Failed to read file',
+        path: filePath,
+      })
+    }
+
+    const fmResult = parseFrontmatter(content)
+    if (!fmResult.ok) {
+      return fmResult
+    }
+
+    const { attributes, body } = fmResult.data
+    const name = getString(attributes, 'name', fileBaseName)
+    const persona = getString(attributes, 'persona', '')
+    const skills = getStringArray(attributes, 'skills')
+    const provider = getString(attributes, 'provider', '')
+    const model = getString(attributes, 'model', '')
+    const description = body
+
+    agents.set(name, { name, persona, skills, provider, model, description })
+  }
+
+  return ok(agents)
+}
+
+/**
+ * グローバルとローカルのエージェントディレクトリから .md ファイルを読み込み、
+ * マージした AgentDef の Map を返す。
+ * ローカル側の同名エージェントがグローバル側を上書きする。
+ */
+export async function loadAgents(
+  globalDir: string,
+  localDir: string,
+): Promise<Result<Map<string, AgentDef>, LoaderError>> {
+  const globalResult = await loadAgentsFromDir(path.join(globalDir, 'agents'))
+  if (!globalResult.ok) {
+    return globalResult
+  }
+
+  const localResult = await loadAgentsFromDir(path.join(localDir, 'agents'))
+  if (!localResult.ok) {
+    return localResult
+  }
+
+  // グローバルを基盤とし、ローカルで上書き
+  const merged = new Map<string, AgentDef>(globalResult.data)
+  for (const [name, agent] of localResult.data) {
+    merged.set(name, agent)
+  }
+
+  return ok(merged)
+}

--- a/src/loader/config-loader.ts
+++ b/src/loader/config-loader.ts
@@ -1,0 +1,232 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import type { Result } from '../result.js'
+import { ok, err } from '../result.js'
+import type { WnConfig, ProviderConfig, McpConfig, McpServerConfig, LoaderError } from './types.js'
+
+const DEFAULT_PROVIDER = 'claude'
+const DEFAULT_MODEL = 'claude-sonnet-4-20250514'
+const DEFAULT_PERSONA = 'default'
+
+/**
+ * Node.js のファイルシステムエラーかどうかを判定する型ガード
+ */
+function isNodeError(e: unknown): e is NodeJS.ErrnoException {
+  return e instanceof Error && 'code' in e
+}
+
+/**
+ * 値がプレーンオブジェクト（Record<string, unknown>）かどうかを判定する型ガード
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * JSON ファイルを読み込み、パース結果を返す。
+ * ファイルが存在しない場合 (ENOENT) は空オブジェクトを返す。
+ * パースエラーの場合は LoaderError を返す。
+ */
+async function readJsonFile(
+  filePath: string,
+): Promise<Result<Record<string, unknown>, LoaderError>> {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8')
+    const parsed: unknown = JSON.parse(content)
+    if (!isPlainObject(parsed)) {
+      return err({
+        code: 'PARSE_ERROR',
+        message: `config.json must be a JSON object: ${filePath}`,
+        path: filePath,
+      })
+    }
+    return ok(parsed)
+  } catch (e: unknown) {
+    if (isNodeError(e) && e.code === 'ENOENT') {
+      return ok({})
+    }
+    if (e instanceof SyntaxError) {
+      return err({
+        code: 'PARSE_ERROR',
+        message: `Invalid JSON in ${filePath}: ${e.message}`,
+        path: filePath,
+      })
+    }
+    if (isNodeError(e)) {
+      return err({
+        code: 'IO_ERROR',
+        message: `Failed to read ${filePath}: ${e.message}`,
+        path: filePath,
+      })
+    }
+    return err({
+      code: 'IO_ERROR',
+      message: `Failed to read ${filePath}: unknown error`,
+      path: filePath,
+    })
+  }
+}
+
+/**
+ * 2 つのオブジェクトを再帰的にディープマージする。
+ * 配列は上書き（マージしない）。オブジェクトは再帰的にマージ。
+ */
+function deepMerge(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base }
+
+  for (const key of Object.keys(override)) {
+    const baseVal = base[key]
+    const overrideVal = override[key]
+
+    if (isPlainObject(baseVal) && isPlainObject(overrideVal)) {
+      result[key] = deepMerge(baseVal, overrideVal)
+    } else {
+      result[key] = overrideVal
+    }
+  }
+
+  return result
+}
+
+/**
+ * オブジェクト内の全文字列値に対して ${VAR_NAME} パターンを
+ * process.env の値で置換する。未定義の環境変数は元の文字列のまま残す。
+ */
+function substituteEnvVars(obj: unknown): unknown {
+  if (typeof obj === 'string') {
+    return obj.replace(/\$\{([^}]+)\}/g, (_match, varName: string) => {
+      const envValue = process.env[varName]
+      return envValue !== undefined ? envValue : _match
+    })
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => substituteEnvVars(item))
+  }
+
+  if (isPlainObject(obj)) {
+    const result: Record<string, unknown> = {}
+    for (const key of Object.keys(obj)) {
+      result[key] = substituteEnvVars(obj[key])
+    }
+    return result
+  }
+
+  // number, boolean, null など — そのまま返す
+  return obj
+}
+
+/**
+ * unknown 値が ProviderConfig の形状かどうかを判定する型ガード
+ */
+function isProviderConfig(value: unknown): value is ProviderConfig {
+  if (!isPlainObject(value)) return false
+  if ('apiKey' in value && typeof value['apiKey'] !== 'string') return false
+  if ('baseUrl' in value && typeof value['baseUrl'] !== 'string') return false
+  return true
+}
+
+/**
+ * unknown 値が McpServerConfig の形状かどうかを判定する型ガード
+ */
+function isMcpServerConfig(value: unknown): value is McpServerConfig {
+  if (!isPlainObject(value)) return false
+  if (typeof value['name'] !== 'string') return false
+  if (typeof value['command'] !== 'string') return false
+  if (!Array.isArray(value['args'])) return false
+  return value['args'].every((a) => typeof a === 'string')
+}
+
+/**
+ * unknown 値が McpConfig の形状かどうかを判定する型ガード
+ */
+function isMcpConfig(value: unknown): value is McpConfig {
+  if (!isPlainObject(value)) return false
+  if (!Array.isArray(value['servers'])) return false
+  return value['servers'].every((s) => isMcpServerConfig(s))
+}
+
+/**
+ * unknown な providers オブジェクトを WnConfig['providers'] に安全に変換する
+ */
+function toProviders(value: unknown): WnConfig['providers'] {
+  if (!isPlainObject(value)) return {}
+  const result: Record<string, ProviderConfig> = {}
+  for (const key of Object.keys(value)) {
+    const entry = value[key]
+    if (isProviderConfig(entry)) {
+      result[key] = entry
+    }
+  }
+  return result
+}
+
+/**
+ * 設定ファイルを読み込み、マージし、環境変数を置換して WnConfig を返す。
+ *
+ * 優先順位: CLI オーバーライド > ローカル config.json > グローバル config.json > デフォルト値
+ */
+export async function loadConfig(
+  globalDir: string,
+  localDir: string,
+  cliOverrides?: Partial<Pick<WnConfig, 'defaultProvider' | 'defaultModel' | 'defaultPersona'>>,
+): Promise<Result<WnConfig, LoaderError>> {
+  // 1. グローバル config.json を読み込む
+  const globalResult = await readJsonFile(path.join(globalDir, 'config.json'))
+  if (!globalResult.ok) {
+    return globalResult
+  }
+
+  // 2. ローカル config.json を読み込む
+  const localResult = await readJsonFile(path.join(localDir, 'config.json'))
+  if (!localResult.ok) {
+    return localResult
+  }
+
+  // 3. ディープマージ: グローバル ← ローカル
+  let merged = deepMerge(globalResult.data, localResult.data)
+
+  // 4. CLI オーバーライドを適用（undefined でないもののみ）
+  if (cliOverrides) {
+    if (cliOverrides.defaultProvider !== undefined) {
+      merged = { ...merged, defaultProvider: cliOverrides.defaultProvider }
+    }
+    if (cliOverrides.defaultModel !== undefined) {
+      merged = { ...merged, defaultModel: cliOverrides.defaultModel }
+    }
+    if (cliOverrides.defaultPersona !== undefined) {
+      merged = { ...merged, defaultPersona: cliOverrides.defaultPersona }
+    }
+  }
+
+  // 5. 環境変数を置換
+  const substituted = substituteEnvVars(merged)
+
+  if (!isPlainObject(substituted)) {
+    return err({
+      code: 'PARSE_ERROR',
+      message: 'Unexpected: substituted config is not an object',
+    })
+  }
+
+  // 6. デフォルト値を適用
+  const config: WnConfig = {
+    defaultProvider:
+      typeof substituted['defaultProvider'] === 'string'
+        ? substituted['defaultProvider']
+        : DEFAULT_PROVIDER,
+    defaultModel:
+      typeof substituted['defaultModel'] === 'string' ? substituted['defaultModel'] : DEFAULT_MODEL,
+    defaultPersona:
+      typeof substituted['defaultPersona'] === 'string'
+        ? substituted['defaultPersona']
+        : DEFAULT_PERSONA,
+    providers: toProviders(substituted['providers']),
+    ...(isMcpConfig(substituted['mcp']) ? { mcp: substituted['mcp'] } : {}),
+  }
+
+  return ok(config)
+}

--- a/src/loader/frontmatter.ts
+++ b/src/loader/frontmatter.ts
@@ -1,0 +1,77 @@
+import type { Result } from '../result.js'
+import { ok, err } from '../result.js'
+import type { FrontmatterResult, LoaderError } from './types.js'
+
+const LINE_REGEX = /^(\w[\w-]*)\s*:\s*(.*)$/
+const ARRAY_REGEX = /^\[([^\]]*)\]$/
+
+/**
+ * Markdown frontmatter をパースする
+ *
+ * `---` デリミタで囲まれた YAML-like なキー・値ペアを抽出し、
+ * 残りをボディ文字列として返す。
+ */
+export function parseFrontmatter(raw: string): Result<FrontmatterResult, LoaderError> {
+  // Normalize CRLF to LF
+  const content = raw.replace(/\r\n/g, '\n')
+  const lines = content.split('\n')
+
+  // Check for opening delimiter
+  if (lines[0] !== '---') {
+    return ok({ attributes: {}, body: content })
+  }
+
+  // Find closing delimiter
+  let endIndex = -1
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') {
+      endIndex = i
+      break
+    }
+  }
+
+  if (endIndex === -1) {
+    return err({
+      code: 'PARSE_ERROR',
+      message: 'Frontmatter opening delimiter found but no closing delimiter',
+    })
+  }
+
+  // Parse YAML lines
+  const attributes: Record<string, string | readonly string[]> = {}
+  for (let i = 1; i < endIndex; i++) {
+    const line = lines[i]
+    if (line === undefined) continue
+    const trimmed = line.trim()
+    if (trimmed === '' || trimmed.startsWith('#')) continue
+
+    const match = LINE_REGEX.exec(trimmed)
+    if (match === null) continue
+
+    const key = match[1]
+    const rawVal = match[2]
+    if (key === undefined || rawVal === undefined) continue
+
+    const val = rawVal.trim()
+    const arrayMatch = ARRAY_REGEX.exec(val)
+    if (arrayMatch !== null) {
+      const inner = arrayMatch[1]
+      if (inner === undefined || inner.trim() === '') {
+        attributes[key] = []
+      } else {
+        attributes[key] = inner
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      }
+    } else {
+      attributes[key] = val
+    }
+  }
+
+  // Body: everything after the closing delimiter, strip leading newline
+  const bodyLines = lines.slice(endIndex + 1)
+  const body = bodyLines.join('\n').replace(/^\n/, '')
+
+  return ok({ attributes, body })
+}

--- a/src/loader/persona-loader.ts
+++ b/src/loader/persona-loader.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { Result } from '../result.js'
+import { ok, err } from '../result.js'
+import type { Persona, LoaderError } from './types.js'
+
+/**
+ * NodeJS.ErrnoException 型ガード
+ */
+function isNodeError(e: unknown): e is NodeJS.ErrnoException {
+  return e instanceof Error && 'code' in e
+}
+
+/**
+ * 指定ディレクトリから .md ファイルを読み込み、Persona の Map を返す。
+ * ディレクトリが存在しない場合（ENOENT）は空 Map を返す。
+ */
+async function loadPersonasFromDir(
+  dir: string,
+): Promise<Result<Map<string, Persona>, LoaderError>> {
+  let entries: fs.Dirent[]
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true })
+  } catch (e: unknown) {
+    if (isNodeError(e) && e.code === 'ENOENT') {
+      return ok(new Map<string, Persona>())
+    }
+    return err({
+      code: 'IO_ERROR',
+      message: isNodeError(e) ? e.message : 'Unknown IO error',
+      path: dir,
+    })
+  }
+
+  const personas = new Map<string, Persona>()
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue
+    if (!entry.name.endsWith('.md')) continue
+
+    const name = path.basename(entry.name, '.md')
+    const filePath = path.join(dir, entry.name)
+
+    try {
+      const content = await fs.promises.readFile(filePath, 'utf-8')
+      personas.set(name, { name, content })
+    } catch (e: unknown) {
+      return err({
+        code: 'IO_ERROR',
+        message: isNodeError(e) ? e.message : 'Failed to read file',
+        path: filePath,
+      })
+    }
+  }
+
+  return ok(personas)
+}
+
+/**
+ * グローバルとローカルのペルソナディレクトリから .md ファイルを読み込み、
+ * マージした Persona の Map を返す。
+ * ローカル側の同名ペルソナがグローバル側を上書きする。
+ */
+export async function loadPersonas(
+  globalDir: string,
+  localDir: string,
+): Promise<Result<Map<string, Persona>, LoaderError>> {
+  const globalResult = await loadPersonasFromDir(path.join(globalDir, 'personas'))
+  if (!globalResult.ok) {
+    return globalResult
+  }
+
+  const localResult = await loadPersonasFromDir(path.join(localDir, 'personas'))
+  if (!localResult.ok) {
+    return localResult
+  }
+
+  // グローバルを基盤とし、ローカルで上書き
+  const merged = new Map<string, Persona>(globalResult.data)
+  for (const [name, persona] of localResult.data) {
+    merged.set(name, persona)
+  }
+
+  return ok(merged)
+}

--- a/src/loader/skill-loader.ts
+++ b/src/loader/skill-loader.ts
@@ -1,0 +1,144 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { Result } from '../result.js'
+import { ok, err } from '../result.js'
+import type { Skill, LoaderError } from './types.js'
+import { parseFrontmatter } from './frontmatter.js'
+
+/**
+ * NodeJS.ErrnoException 型ガード
+ */
+function isNodeError(e: unknown): e is NodeJS.ErrnoException {
+  return e instanceof Error && 'code' in e
+}
+
+/**
+ * frontmatter の属性値を文字列として安全に取得する。
+ * 値が string でなければ undefined を返す。
+ */
+function getStringAttr(
+  attributes: Readonly<Record<string, string | readonly string[]>>,
+  key: string,
+): string | undefined {
+  const value = attributes[key]
+  if (typeof value === 'string') {
+    return value
+  }
+  return undefined
+}
+
+/**
+ * frontmatter の属性値を文字列配列として安全に取得する。
+ * 値が readonly string[] であればそのまま返し、存在しなければ空配列を返す。
+ */
+function getStringArrayAttr(
+  attributes: Readonly<Record<string, string | readonly string[]>>,
+  key: string,
+): readonly string[] {
+  const value = attributes[key]
+  if (Array.isArray(value)) {
+    return value as readonly string[]
+  }
+  return []
+}
+
+/**
+ * 指定ディレクトリ内のスキルサブディレクトリから SKILL.md を読み込み、
+ * Skill の Map を返す。
+ * ディレクトリが存在しない場合（ENOENT）は空 Map を返す。
+ */
+async function loadSkillsFromDir(dir: string): Promise<Result<Map<string, Skill>, LoaderError>> {
+  let entries: fs.Dirent[]
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true })
+  } catch (e: unknown) {
+    if (isNodeError(e) && e.code === 'ENOENT') {
+      return ok(new Map<string, Skill>())
+    }
+    return err({
+      code: 'IO_ERROR',
+      message: isNodeError(e) ? e.message : 'Unknown IO error',
+      path: dir,
+    })
+  }
+
+  const skills = new Map<string, Skill>()
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+
+    const dirName = entry.name
+    const skillFilePath = path.join(dir, dirName, 'SKILL.md')
+
+    // SKILL.md が存在しないディレクトリはスキップ
+    let rawContent: string
+    try {
+      rawContent = await fs.promises.readFile(skillFilePath, 'utf-8')
+    } catch (e: unknown) {
+      if (isNodeError(e) && e.code === 'ENOENT') {
+        continue
+      }
+      return err({
+        code: 'IO_ERROR',
+        message: isNodeError(e) ? e.message : 'Failed to read file',
+        path: skillFilePath,
+      })
+    }
+
+    // frontmatter をパース
+    const parseResult = parseFrontmatter(rawContent)
+    if (!parseResult.ok) {
+      return parseResult
+    }
+
+    const { attributes, body } = parseResult.data
+
+    // name: frontmatter に指定があればそれを使い、なければディレクトリ名をフォールバック
+    const name = getStringAttr(attributes, 'name') ?? dirName
+
+    // description: 必須フィールド
+    const description = getStringAttr(attributes, 'description')
+    if (description === undefined || description === '') {
+      return err({
+        code: 'VALIDATION_ERROR',
+        message: `Skill "${name}" is missing required field: description`,
+        path: skillFilePath,
+      })
+    }
+
+    // tools: オプション、デフォルトは空配列
+    const tools = getStringArrayAttr(attributes, 'tools')
+
+    skills.set(name, { name, description, tools, body })
+  }
+
+  return ok(skills)
+}
+
+/**
+ * グローバルとローカルのスキルディレクトリから SKILL.md を読み込み、
+ * マージした Skill の Map を返す。
+ * ローカル側の同名スキルがグローバル側を上書きする。
+ */
+export async function loadSkills(
+  globalDir: string,
+  localDir: string,
+): Promise<Result<Map<string, Skill>, LoaderError>> {
+  const globalResult = await loadSkillsFromDir(path.join(globalDir, 'skills'))
+  if (!globalResult.ok) {
+    return globalResult
+  }
+
+  const localResult = await loadSkillsFromDir(path.join(localDir, 'skills'))
+  if (!localResult.ok) {
+    return localResult
+  }
+
+  // グローバルを基盤とし、ローカルで上書き
+  const merged = new Map<string, Skill>(globalResult.data)
+  for (const [name, skill] of localResult.data) {
+    merged.set(name, skill)
+  }
+
+  return ok(merged)
+}

--- a/src/loader/types.ts
+++ b/src/loader/types.ts
@@ -1,0 +1,66 @@
+/** MCP サーバー設定 */
+export interface McpServerConfig {
+  readonly name: string
+  readonly command: string
+  readonly args: readonly string[]
+}
+
+/** MCP 設定 */
+export interface McpConfig {
+  readonly servers: readonly McpServerConfig[]
+}
+
+/** LLM プロバイダー設定 */
+export interface ProviderConfig {
+  readonly apiKey?: string
+  readonly baseUrl?: string
+}
+
+/** wn-core グローバル設定 */
+export interface WnConfig {
+  readonly defaultProvider: string
+  readonly defaultModel: string
+  readonly defaultPersona: string
+  readonly providers: Readonly<Record<string, ProviderConfig>>
+  readonly mcp?: McpConfig
+}
+
+/** ペルソナ定義 */
+export interface Persona {
+  readonly name: string
+  readonly content: string
+}
+
+/** スキル定義 */
+export interface Skill {
+  readonly name: string
+  readonly description: string
+  readonly tools: readonly string[]
+  readonly body: string
+}
+
+/** エージェント定義 */
+export interface AgentDef {
+  readonly name: string
+  readonly persona: string
+  readonly skills: readonly string[]
+  readonly provider: string
+  readonly model: string
+  readonly description: string
+}
+
+/** frontmatter パース結果 */
+export interface FrontmatterResult {
+  readonly attributes: Readonly<Record<string, string | readonly string[]>>
+  readonly body: string
+}
+
+/** Loader エラーコード */
+export type LoaderErrorCode = 'FILE_NOT_FOUND' | 'PARSE_ERROR' | 'VALIDATION_ERROR' | 'IO_ERROR'
+
+/** Loader エラー */
+export interface LoaderError {
+  readonly code: LoaderErrorCode
+  readonly message: string
+  readonly path?: string
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,6 +9,11 @@ import {
   createGrepTool,
   createShellTool,
   getShellConfig,
+  parseFrontmatter,
+  loadConfig,
+  loadPersonas,
+  loadSkills,
+  loadAgents,
 } from '../src/index.js'
 import type { ShellConfig } from '../src/index.js'
 import type {
@@ -26,6 +31,16 @@ import type {
   SubAgentHandle,
   AgentConfig,
   SubAgentRunner,
+  WnConfig,
+  ProviderConfig,
+  McpConfig,
+  McpServerConfig,
+  Persona,
+  Skill,
+  AgentDef,
+  FrontmatterResult,
+  LoaderError,
+  LoaderErrorCode,
 } from '../src/index.js'
 
 describe('wn-core', () => {
@@ -113,5 +128,57 @@ describe('wn-core', () => {
     // ShellConfig 型が利用可能
     const config: ShellConfig = getShellConfig('linux')
     expect(config.shell).toBe('/bin/sh')
+  })
+
+  it('Loader 関数がエクスポートされている', () => {
+    expect(typeof parseFrontmatter).toBe('function')
+    expect(typeof loadConfig).toBe('function')
+    expect(typeof loadPersonas).toBe('function')
+    expect(typeof loadSkills).toBe('function')
+    expect(typeof loadAgents).toBe('function')
+  })
+
+  it('Loader 型がコンパイル時に利用可能（型チェック用）', () => {
+    const wnConfig: WnConfig = {
+      defaultProvider: 'claude',
+      defaultModel: 'claude-sonnet-4-20250514',
+      defaultPersona: 'default',
+      providers: {},
+    }
+    expect(wnConfig.defaultProvider).toBe('claude')
+
+    const providerConfig: ProviderConfig = { apiKey: 'test' }
+    expect(providerConfig.apiKey).toBe('test')
+
+    const mcpServer: McpServerConfig = { name: 's', command: 'c', args: [] }
+    expect(mcpServer.name).toBe('s')
+
+    const mcpConfig: McpConfig = { servers: [mcpServer] }
+    expect(mcpConfig.servers).toHaveLength(1)
+
+    const persona: Persona = { name: 'default', content: 'hello' }
+    expect(persona.name).toBe('default')
+
+    const skill: Skill = { name: 'scan', description: 'scan skill', tools: ['shell'], body: '' }
+    expect(skill.name).toBe('scan')
+
+    const agentDef: AgentDef = {
+      name: 'recon',
+      persona: 'default',
+      skills: ['scan'],
+      provider: 'claude',
+      model: 'sonnet',
+      description: 'recon agent',
+    }
+    expect(agentDef.name).toBe('recon')
+
+    const frontmatter: FrontmatterResult = { attributes: {}, body: '' }
+    expect(frontmatter.body).toBe('')
+
+    const loaderError: LoaderError = { code: 'PARSE_ERROR', message: 'bad' }
+    expect(loaderError.code).toBe('PARSE_ERROR')
+
+    const code: LoaderErrorCode = 'IO_ERROR'
+    expect(code).toBe('IO_ERROR')
   })
 })

--- a/tests/loader/agent-loader.test.ts
+++ b/tests/loader/agent-loader.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { loadAgents } from '../../src/loader/agent-loader.js'
+
+describe('loadAgents', () => {
+  let globalDir: string
+  let localDir: string
+
+  beforeEach(() => {
+    globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wn-global-'))
+    localDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wn-local-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(globalDir, { recursive: true, force: true })
+    fs.rmSync(localDir, { recursive: true, force: true })
+  })
+
+  it('エージェント定義の frontmatter から全フィールドを抽出する', async () => {
+    const agentsDir = path.join(globalDir, 'agents')
+    fs.mkdirSync(agentsDir)
+    fs.writeFileSync(
+      path.join(agentsDir, 'reviewer.md'),
+      [
+        '---',
+        'name: reviewer',
+        'persona: code-reviewer',
+        'skills: [read, grep]',
+        'provider: claude',
+        'model: claude-sonnet-4-20250514',
+        '---',
+        'コードレビューを行うサブエージェントです。',
+      ].join('\n'),
+      'utf-8',
+    )
+
+    const result = await loadAgents(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(1)
+      const agent = result.data.get('reviewer')
+      expect(agent).toBeDefined()
+      expect(agent?.name).toBe('reviewer')
+      expect(agent?.persona).toBe('code-reviewer')
+      expect(agent?.skills).toEqual(['read', 'grep'])
+      expect(agent?.provider).toBe('claude')
+      expect(agent?.model).toBe('claude-sonnet-4-20250514')
+      expect(agent?.description).toBe('コードレビューを行うサブエージェントです。')
+    }
+  })
+
+  it('ボディを description として取得する', async () => {
+    const agentsDir = path.join(globalDir, 'agents')
+    fs.mkdirSync(agentsDir)
+    fs.writeFileSync(
+      path.join(agentsDir, 'helper.md'),
+      [
+        '---',
+        'name: helper',
+        '---',
+        'これはヘルパーエージェントです。',
+        '複数行の説明も可能です。',
+      ].join('\n'),
+      'utf-8',
+    )
+
+    const result = await loadAgents(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const agent = result.data.get('helper')
+      expect(agent).toBeDefined()
+      expect(agent?.description).toBe('これはヘルパーエージェントです。\n複数行の説明も可能です。')
+    }
+  })
+
+  it('ローカルのエージェントがグローバルの同名エージェントを上書きする', async () => {
+    const globalAgentsDir = path.join(globalDir, 'agents')
+    const localAgentsDir = path.join(localDir, 'agents')
+    fs.mkdirSync(globalAgentsDir)
+    fs.mkdirSync(localAgentsDir)
+    fs.writeFileSync(
+      path.join(globalAgentsDir, 'reviewer.md'),
+      ['---', 'name: reviewer', 'provider: openai', '---', 'Global reviewer'].join('\n'),
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(localAgentsDir, 'reviewer.md'),
+      ['---', 'name: reviewer', 'provider: claude', '---', 'Local reviewer'].join('\n'),
+      'utf-8',
+    )
+
+    const result = await loadAgents(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(1)
+      const agent = result.data.get('reviewer')
+      expect(agent).toBeDefined()
+      expect(agent?.provider).toBe('claude')
+      expect(agent?.description).toBe('Local reviewer')
+    }
+  })
+
+  it('異なる名前のエージェントは両方マージされる', async () => {
+    const globalAgentsDir = path.join(globalDir, 'agents')
+    const localAgentsDir = path.join(localDir, 'agents')
+    fs.mkdirSync(globalAgentsDir)
+    fs.mkdirSync(localAgentsDir)
+    fs.writeFileSync(
+      path.join(globalAgentsDir, 'a.md'),
+      ['---', 'name: a', '---', 'Agent A'].join('\n'),
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(localAgentsDir, 'b.md'),
+      ['---', 'name: b', '---', 'Agent B'].join('\n'),
+      'utf-8',
+    )
+
+    const result = await loadAgents(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(2)
+      expect(result.data.get('a')?.description).toBe('Agent A')
+      expect(result.data.get('b')?.description).toBe('Agent B')
+    }
+  })
+
+  it('agents/ ディレクトリが存在しない場合に空 Map を返す', async () => {
+    // globalDir と localDir には agents/ サブディレクトリを作成しない
+    const result = await loadAgents(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(0)
+    }
+  })
+
+  it('name が frontmatter にない場合、ファイル名をフォールバックする', async () => {
+    const agentsDir = path.join(globalDir, 'agents')
+    fs.mkdirSync(agentsDir)
+    fs.writeFileSync(
+      path.join(agentsDir, 'fallback.md'),
+      ['---', 'persona: default', '---', 'No name in frontmatter'].join('\n'),
+      'utf-8',
+    )
+
+    const result = await loadAgents(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const agent = result.data.get('fallback')
+      expect(agent).toBeDefined()
+      expect(agent?.name).toBe('fallback')
+      expect(agent?.persona).toBe('default')
+    }
+  })
+
+  it('.md 以外のファイルを無視する', async () => {
+    const agentsDir = path.join(globalDir, 'agents')
+    fs.mkdirSync(agentsDir)
+    fs.writeFileSync(
+      path.join(agentsDir, 'valid.md'),
+      ['---', 'name: valid', '---', 'Valid agent'].join('\n'),
+      'utf-8',
+    )
+    fs.writeFileSync(path.join(agentsDir, 'notes.txt'), 'Not an agent', 'utf-8')
+
+    const result = await loadAgents(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(1)
+      expect(result.data.has('valid')).toBe(true)
+      expect(result.data.has('notes')).toBe(false)
+    }
+  })
+})

--- a/tests/loader/config-loader.test.ts
+++ b/tests/loader/config-loader.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { loadConfig } from '../../src/loader/config-loader.js'
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'wn-config-test-'))
+}
+
+function writeConfig(dir: string, data: unknown): void {
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify(data), 'utf-8')
+}
+
+describe('loadConfig', () => {
+  let globalDir: string
+  let localDir: string
+
+  beforeEach(() => {
+    globalDir = makeTmpDir()
+    localDir = makeTmpDir()
+  })
+
+  afterEach(() => {
+    fs.rmSync(globalDir, { recursive: true, force: true })
+    fs.rmSync(localDir, { recursive: true, force: true })
+  })
+
+  // ── JSON 読み込み ──────────────────────────────────────────
+
+  describe('JSON 読み込み', () => {
+    it('グローバルの config.json を読み込める', async () => {
+      writeConfig(globalDir, {
+        defaultProvider: 'openai',
+        defaultModel: 'gpt-4o',
+      })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultProvider).toBe('openai')
+        expect(result.data.defaultModel).toBe('gpt-4o')
+      }
+    })
+
+    it('ローカルの config.json がグローバルを上書きする', async () => {
+      writeConfig(globalDir, {
+        defaultProvider: 'openai',
+        defaultModel: 'gpt-4o',
+      })
+      writeConfig(localDir, {
+        defaultProvider: 'claude',
+      })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultProvider).toBe('claude')
+        // グローバルの defaultModel は残る
+        expect(result.data.defaultModel).toBe('gpt-4o')
+      }
+    })
+
+    it('config.json が存在しない場合にデフォルト値を返す', async () => {
+      // config.json を作らない
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultProvider).toBe('claude')
+        expect(result.data.defaultModel).toBe('claude-sonnet-4-20250514')
+        expect(result.data.defaultPersona).toBe('default')
+        expect(result.data.providers).toStrictEqual({})
+      }
+    })
+
+    it('不正な JSON に対してエラーを返す', async () => {
+      fs.writeFileSync(path.join(globalDir, 'config.json'), '{invalid json}', 'utf-8')
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.code).toBe('PARSE_ERROR')
+        expect(result.error.path).toContain('config.json')
+      }
+    })
+
+    it('ディレクトリが存在しない場合にデフォルト値を返す', async () => {
+      const nonExistentGlobal = path.join(globalDir, 'nonexistent')
+      const nonExistentLocal = path.join(localDir, 'nonexistent')
+
+      const result = await loadConfig(nonExistentGlobal, nonExistentLocal)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultProvider).toBe('claude')
+        expect(result.data.defaultModel).toBe('claude-sonnet-4-20250514')
+        expect(result.data.defaultPersona).toBe('default')
+        expect(result.data.providers).toStrictEqual({})
+      }
+    })
+  })
+
+  // ── ディープマージ ──────────────────────────────────────────
+
+  describe('ディープマージ', () => {
+    it('ネストされたオブジェクトを再帰的にマージする (providers object)', async () => {
+      writeConfig(globalDir, {
+        providers: {
+          claude: { apiKey: '${CLAUDE_KEY}' },
+          openai: { apiKey: '${OPENAI_KEY}' },
+        },
+      })
+      writeConfig(localDir, {
+        providers: {
+          openai: { baseUrl: 'http://localhost:8080' },
+        },
+      })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        // claude プロバイダーはグローバルから維持される
+        expect(result.data.providers['claude']).toBeDefined()
+        // openai はマージされる（apiKey はグローバルから、baseUrl はローカルから）
+        expect(result.data.providers['openai']?.apiKey).toBe('${OPENAI_KEY}')
+        expect(result.data.providers['openai']?.baseUrl).toBe('http://localhost:8080')
+      }
+    })
+
+    it('ローカルのプロパティがグローバルを上書きする (defaultProvider)', async () => {
+      writeConfig(globalDir, { defaultProvider: 'openai' })
+      writeConfig(localDir, { defaultProvider: 'claude' })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultProvider).toBe('claude')
+      }
+    })
+
+    it('配列は上書きされる（マージされない）(mcp.servers)', async () => {
+      writeConfig(globalDir, {
+        mcp: {
+          servers: [{ name: 'global-server', command: 'cmd1', args: [] }],
+        },
+      })
+      writeConfig(localDir, {
+        mcp: {
+          servers: [{ name: 'local-server', command: 'cmd2', args: ['--flag'] }],
+        },
+      })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.mcp?.servers).toHaveLength(1)
+        expect(result.data.mcp?.servers[0]?.name).toBe('local-server')
+      }
+    })
+
+    it('グローバルにないプロパティがローカルから追加される', async () => {
+      writeConfig(globalDir, { defaultProvider: 'openai' })
+      writeConfig(localDir, { defaultPersona: 'pentester' })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultProvider).toBe('openai')
+        expect(result.data.defaultPersona).toBe('pentester')
+      }
+    })
+  })
+
+  // ── CLI オーバーライド ──────────────────────────────────────
+
+  describe('CLI オーバーライド', () => {
+    it('defaultProvider を CLI から上書きできる', async () => {
+      writeConfig(globalDir, { defaultProvider: 'openai' })
+
+      const result = await loadConfig(globalDir, localDir, {
+        defaultProvider: 'ollama',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultProvider).toBe('ollama')
+      }
+    })
+
+    it('defaultModel を CLI から上書きできる', async () => {
+      writeConfig(globalDir, { defaultModel: 'gpt-4o' })
+
+      const result = await loadConfig(globalDir, localDir, {
+        defaultModel: 'claude-opus-4-20250514',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultModel).toBe('claude-opus-4-20250514')
+      }
+    })
+
+    it('defaultPersona を CLI から上書きできる', async () => {
+      writeConfig(globalDir, { defaultPersona: 'default' })
+
+      const result = await loadConfig(globalDir, localDir, {
+        defaultPersona: 'pentester',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultPersona).toBe('pentester')
+      }
+    })
+
+    it('CLI オーバーライドが undefined の場合は何もしない', async () => {
+      writeConfig(globalDir, {
+        defaultProvider: 'openai',
+        defaultModel: 'gpt-4o',
+        defaultPersona: 'default',
+      })
+
+      const result = await loadConfig(globalDir, localDir, {
+        defaultProvider: undefined,
+        defaultModel: undefined,
+        defaultPersona: undefined,
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultProvider).toBe('openai')
+        expect(result.data.defaultModel).toBe('gpt-4o')
+        expect(result.data.defaultPersona).toBe('default')
+      }
+    })
+  })
+
+  // ── 環境変数置換 ──────────────────────────────────────────
+
+  describe('環境変数置換', () => {
+    beforeEach(() => {
+      process.env['WN_TEST_API_KEY'] = 'sk-test-12345'
+      process.env['WN_TEST_BASE_URL'] = 'http://localhost:9090'
+    })
+
+    afterEach(() => {
+      delete process.env['WN_TEST_API_KEY']
+      delete process.env['WN_TEST_BASE_URL']
+    })
+
+    it('${VAR_NAME} を process.env の値に置換する', async () => {
+      writeConfig(globalDir, {
+        providers: {
+          claude: { apiKey: '${WN_TEST_API_KEY}' },
+        },
+      })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.providers['claude']?.apiKey).toBe('sk-test-12345')
+      }
+    })
+
+    it('未定義の環境変数は元の文字列のまま残す', async () => {
+      writeConfig(globalDir, {
+        providers: {
+          claude: { apiKey: '${UNDEFINED_VAR_XXXXXX}' },
+        },
+      })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.providers['claude']?.apiKey).toBe('${UNDEFINED_VAR_XXXXXX}')
+      }
+    })
+
+    it('ネストされたオブジェクト内の文字列も置換する', async () => {
+      writeConfig(globalDir, {
+        providers: {
+          openai: {
+            apiKey: '${WN_TEST_API_KEY}',
+            baseUrl: '${WN_TEST_BASE_URL}',
+          },
+        },
+      })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.providers['openai']?.apiKey).toBe('sk-test-12345')
+        expect(result.data.providers['openai']?.baseUrl).toBe('http://localhost:9090')
+      }
+    })
+
+    it('配列内の文字列も置換する (mcp.servers[].command)', async () => {
+      writeConfig(globalDir, {
+        mcp: {
+          servers: [
+            {
+              name: 'test',
+              command: '${WN_TEST_BASE_URL}/bin',
+              args: ['--key', '${WN_TEST_API_KEY}'],
+            },
+          ],
+        },
+      })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.mcp?.servers[0]?.command).toBe('http://localhost:9090/bin')
+        expect(result.data.mcp?.servers[0]?.args[0]).toBe('--key')
+        expect(result.data.mcp?.servers[0]?.args[1]).toBe('sk-test-12345')
+      }
+    })
+
+    it('文字列以外の値は変更しない', async () => {
+      writeConfig(globalDir, {
+        providers: {
+          claude: { apiKey: '${WN_TEST_API_KEY}' },
+        },
+        mcp: {
+          servers: [{ name: 'test', command: 'cmd', args: [] }],
+        },
+      })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        // 配列は配列のまま
+        expect(Array.isArray(result.data.mcp?.servers)).toBe(true)
+        // オブジェクトはオブジェクトのまま
+        expect(typeof result.data.providers).toBe('object')
+      }
+    })
+  })
+
+  // ── デフォルト値 ──────────────────────────────────────────
+
+  describe('デフォルト値', () => {
+    it('defaultProvider が未指定の場合に "claude" をデフォルトとする', async () => {
+      writeConfig(globalDir, {
+        defaultModel: 'some-model',
+      })
+
+      const result = await loadConfig(globalDir, localDir)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data.defaultProvider).toBe('claude')
+        expect(result.data.defaultModel).toBe('some-model')
+        expect(result.data.defaultPersona).toBe('default')
+        expect(result.data.providers).toStrictEqual({})
+      }
+    })
+  })
+})

--- a/tests/loader/frontmatter.test.ts
+++ b/tests/loader/frontmatter.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import { parseFrontmatter } from '../../src/loader/frontmatter.js'
+
+describe('parseFrontmatter', () => {
+  it('frontmatter 付きの文字列からキー・値とボディを抽出する', () => {
+    const input = '---\nname: test\ndescription: hello world\n---\nThis is the body.'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({
+        name: 'test',
+        description: 'hello world',
+      })
+      expect(result.data.body).toBe('This is the body.')
+    }
+  })
+
+  it('インライン配列を string[] としてパースする', () => {
+    const input = '---\ntools: [shell, read]\n---\nbody'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({
+        tools: ['shell', 'read'],
+      })
+      expect(result.data.body).toBe('body')
+    }
+  })
+
+  it('frontmatter がない場合、全体をボディとして返す', () => {
+    const input = 'Just plain text\nwith multiple lines.'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({})
+      expect(result.data.body).toBe('Just plain text\nwith multiple lines.')
+    }
+  })
+
+  it('空の frontmatter（--- のみ）を正しく扱う', () => {
+    const input = '---\n---\nbody'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({})
+      expect(result.data.body).toBe('body')
+    }
+  })
+
+  it('ボディが空の場合、空文字列を返す', () => {
+    const input = '---\nname: test\n---'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({ name: 'test' })
+      expect(result.data.body).toBe('')
+    }
+  })
+
+  it('コメント行を無視する', () => {
+    const input = '---\n# comment\nname: test\n# another comment\n---\nbody'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({ name: 'test' })
+      expect(result.data.body).toBe('body')
+    }
+  })
+
+  it('空行を無視する', () => {
+    const input = '---\nname: test\n\ndescription: hello\n\n---\nbody'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({
+        name: 'test',
+        description: 'hello',
+      })
+      expect(result.data.body).toBe('body')
+    }
+  })
+
+  it('値の前後の空白をトリムする', () => {
+    const input = '---\nname:  hello \n---\nbody'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({ name: 'hello' })
+    }
+  })
+
+  it('キーにハイフンを含む場合を正しくパースする', () => {
+    const input = '---\nmy-skill: value\n---\nbody'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({ 'my-skill': 'value' })
+    }
+  })
+
+  it('空の配列 [] を空配列として返す', () => {
+    const input = '---\ntools: []\n---\nbody'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({ tools: [] })
+    }
+  })
+
+  it('配列内の要素の前後空白をトリムする', () => {
+    const input = '---\ntools: [ shell , read ]\n---\nbody'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({
+        tools: ['shell', 'read'],
+      })
+    }
+  })
+
+  it('Windows 改行コード（CRLF）を正しく扱う', () => {
+    const input = '---\r\nname: test\r\n---\r\nbody'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.attributes).toStrictEqual({ name: 'test' })
+      expect(result.data.body).toBe('body')
+    }
+  })
+
+  it('開始デリミタがあるが終了デリミタがない場合にエラーを返す', () => {
+    const input = '---\nname: test\nno closing delimiter'
+    const result = parseFrontmatter(input)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.code).toBe('PARSE_ERROR')
+      expect(result.error.message).toContain('closing delimiter')
+    }
+  })
+})

--- a/tests/loader/persona-loader.test.ts
+++ b/tests/loader/persona-loader.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { loadPersonas } from '../../src/loader/persona-loader.js'
+
+describe('loadPersonas', () => {
+  let globalDir: string
+  let localDir: string
+
+  beforeEach(() => {
+    globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wn-global-'))
+    localDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wn-local-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(globalDir, { recursive: true, force: true })
+    fs.rmSync(localDir, { recursive: true, force: true })
+  })
+
+  it('グローバルディレクトリから .md ファイルを読み込む', async () => {
+    const personasDir = path.join(globalDir, 'personas')
+    fs.mkdirSync(personasDir)
+    fs.writeFileSync(path.join(personasDir, 'default.md'), 'You are a helpful assistant.', 'utf-8')
+
+    const result = await loadPersonas(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(1)
+      const persona = result.data.get('default')
+      expect(persona).toBeDefined()
+      expect(persona?.name).toBe('default')
+      expect(persona?.content).toBe('You are a helpful assistant.')
+    }
+  })
+
+  it('ファイル名（拡張子なし）を persona 名として使う', async () => {
+    const personasDir = path.join(globalDir, 'personas')
+    fs.mkdirSync(personasDir)
+    fs.writeFileSync(path.join(personasDir, 'test-persona.md'), 'Test content', 'utf-8')
+
+    const result = await loadPersonas(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const persona = result.data.get('test-persona')
+      expect(persona).toBeDefined()
+      expect(persona?.name).toBe('test-persona')
+    }
+  })
+
+  it('ファイル全文を content として使う', async () => {
+    const personasDir = path.join(globalDir, 'personas')
+    fs.mkdirSync(personasDir)
+    const multiLineContent = 'Line 1\nLine 2\nLine 3'
+    fs.writeFileSync(path.join(personasDir, 'multi.md'), multiLineContent, 'utf-8')
+
+    const result = await loadPersonas(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const persona = result.data.get('multi')
+      expect(persona).toBeDefined()
+      expect(persona?.content).toBe(multiLineContent)
+    }
+  })
+
+  it('ローカルの persona がグローバルの同名 persona を上書きする', async () => {
+    const globalPersonasDir = path.join(globalDir, 'personas')
+    const localPersonasDir = path.join(localDir, 'personas')
+    fs.mkdirSync(globalPersonasDir)
+    fs.mkdirSync(localPersonasDir)
+    fs.writeFileSync(path.join(globalPersonasDir, 'default.md'), 'Global content', 'utf-8')
+    fs.writeFileSync(path.join(localPersonasDir, 'default.md'), 'Local content', 'utf-8')
+
+    const result = await loadPersonas(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(1)
+      const persona = result.data.get('default')
+      expect(persona).toBeDefined()
+      expect(persona?.content).toBe('Local content')
+    }
+  })
+
+  it('異なる名前の persona は両方マージされる', async () => {
+    const globalPersonasDir = path.join(globalDir, 'personas')
+    const localPersonasDir = path.join(localDir, 'personas')
+    fs.mkdirSync(globalPersonasDir)
+    fs.mkdirSync(localPersonasDir)
+    fs.writeFileSync(path.join(globalPersonasDir, 'a.md'), 'Content A', 'utf-8')
+    fs.writeFileSync(path.join(localPersonasDir, 'b.md'), 'Content B', 'utf-8')
+
+    const result = await loadPersonas(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(2)
+      expect(result.data.get('a')?.content).toBe('Content A')
+      expect(result.data.get('b')?.content).toBe('Content B')
+    }
+  })
+
+  it('personas/ ディレクトリが存在しない場合に空 Map を返す', async () => {
+    // globalDir と localDir には personas/ サブディレクトリを作成しない
+    const result = await loadPersonas(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(0)
+    }
+  })
+
+  it('.md 以外のファイルを無視する', async () => {
+    const personasDir = path.join(globalDir, 'personas')
+    fs.mkdirSync(personasDir)
+    fs.writeFileSync(path.join(personasDir, 'valid.md'), 'Valid persona', 'utf-8')
+    fs.writeFileSync(path.join(personasDir, 'notes.txt'), 'Not a persona', 'utf-8')
+
+    const result = await loadPersonas(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(1)
+      expect(result.data.has('valid')).toBe(true)
+      expect(result.data.has('notes')).toBe(false)
+    }
+  })
+
+  it('空のディレクトリに対して空 Map を返す', async () => {
+    const personasDir = path.join(globalDir, 'personas')
+    fs.mkdirSync(personasDir)
+    // personas/ ディレクトリは存在するが中身は空
+
+    const result = await loadPersonas(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(0)
+    }
+  })
+})

--- a/tests/loader/skill-loader.test.ts
+++ b/tests/loader/skill-loader.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { loadSkills } from '../../src/loader/skill-loader.js'
+
+describe('loadSkills', () => {
+  let globalDir: string
+  let localDir: string
+
+  beforeEach(() => {
+    globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wn-global-'))
+    localDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wn-local-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(globalDir, { recursive: true, force: true })
+    fs.rmSync(localDir, { recursive: true, force: true })
+  })
+
+  it('SKILL.md の frontmatter から name, description, tools を抽出する', async () => {
+    const skillDir = path.join(globalDir, 'skills', 'my-skill')
+    fs.mkdirSync(skillDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      '---\nname: my-skill\ndescription: A test skill\ntools: [shell, read]\n---\n# Steps\n1. Do something\n',
+      'utf-8',
+    )
+
+    const result = await loadSkills(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(1)
+      const skill = result.data.get('my-skill')
+      expect(skill).toBeDefined()
+      expect(skill?.name).toBe('my-skill')
+      expect(skill?.description).toBe('A test skill')
+      expect(skill?.tools).toEqual(['shell', 'read'])
+      expect(skill?.body).toContain('# Steps')
+    }
+  })
+
+  it('SKILL.md のボディを body として取得する', async () => {
+    const skillDir = path.join(globalDir, 'skills', 'body-test')
+    fs.mkdirSync(skillDir, { recursive: true })
+    const multiLineBody = '# Title\n\nParagraph one.\n\nParagraph two.\n'
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      `---\nname: body-test\ndescription: Body test skill\n---\n${multiLineBody}`,
+      'utf-8',
+    )
+
+    const result = await loadSkills(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const skill = result.data.get('body-test')
+      expect(skill).toBeDefined()
+      expect(skill?.body).toBe(multiLineBody)
+    }
+  })
+
+  it('ローカルのスキルがグローバルの同名スキルを上書きする', async () => {
+    const globalSkillDir = path.join(globalDir, 'skills', 'my-skill')
+    const localSkillDir = path.join(localDir, 'skills', 'my-skill')
+    fs.mkdirSync(globalSkillDir, { recursive: true })
+    fs.mkdirSync(localSkillDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(globalSkillDir, 'SKILL.md'),
+      '---\nname: my-skill\ndescription: Global version\n---\nGlobal body\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(localSkillDir, 'SKILL.md'),
+      '---\nname: my-skill\ndescription: Local version\n---\nLocal body\n',
+      'utf-8',
+    )
+
+    const result = await loadSkills(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(1)
+      const skill = result.data.get('my-skill')
+      expect(skill).toBeDefined()
+      expect(skill?.description).toBe('Local version')
+      expect(skill?.body).toBe('Local body\n')
+    }
+  })
+
+  it('異なる名前のスキルは両方マージされる', async () => {
+    const globalSkillDir = path.join(globalDir, 'skills', 'skill-a')
+    const localSkillDir = path.join(localDir, 'skills', 'skill-b')
+    fs.mkdirSync(globalSkillDir, { recursive: true })
+    fs.mkdirSync(localSkillDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(globalSkillDir, 'SKILL.md'),
+      '---\nname: skill-a\ndescription: Skill A\n---\nBody A\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(localSkillDir, 'SKILL.md'),
+      '---\nname: skill-b\ndescription: Skill B\n---\nBody B\n',
+      'utf-8',
+    )
+
+    const result = await loadSkills(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(2)
+      expect(result.data.get('skill-a')?.description).toBe('Skill A')
+      expect(result.data.get('skill-b')?.description).toBe('Skill B')
+    }
+  })
+
+  it('skills/ ディレクトリが存在しない場合に空 Map を返す', async () => {
+    // globalDir と localDir には skills/ サブディレクトリを作成しない
+    const result = await loadSkills(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(0)
+    }
+  })
+
+  it('name が frontmatter にない場合、ディレクトリ名をフォールバックする', async () => {
+    const skillDir = path.join(globalDir, 'skills', 'fallback-name')
+    fs.mkdirSync(skillDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      '---\ndescription: No name field\n---\nSome body\n',
+      'utf-8',
+    )
+
+    const result = await loadSkills(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(1)
+      const skill = result.data.get('fallback-name')
+      expect(skill).toBeDefined()
+      expect(skill?.name).toBe('fallback-name')
+    }
+  })
+
+  it('description が未指定の場合にバリデーションエラーを返す', async () => {
+    const skillDir = path.join(globalDir, 'skills', 'no-desc')
+    fs.mkdirSync(skillDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      '---\nname: no-desc\n---\nSome body\n',
+      'utf-8',
+    )
+
+    const result = await loadSkills(globalDir, localDir)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.code).toBe('VALIDATION_ERROR')
+    }
+  })
+
+  it('SKILL.md が存在しないディレクトリを無視する', async () => {
+    const emptyDir = path.join(globalDir, 'skills', 'empty-dir')
+    const validDir = path.join(globalDir, 'skills', 'valid-skill')
+    fs.mkdirSync(emptyDir, { recursive: true })
+    fs.mkdirSync(validDir, { recursive: true })
+    // empty-dir には SKILL.md を配置しない
+    fs.writeFileSync(
+      path.join(validDir, 'SKILL.md'),
+      '---\nname: valid-skill\ndescription: A valid skill\n---\nBody\n',
+      'utf-8',
+    )
+
+    const result = await loadSkills(globalDir, localDir)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.size).toBe(1)
+      expect(result.data.has('valid-skill')).toBe(true)
+      expect(result.data.has('empty-dir')).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- **frontmatter パーサー**: 外部依存なしの簡易 YAML frontmatter パーサー（`parseFrontmatter()`）
- **config ローダー**: JSON 読み込み + deep merge + `${VAR}` 環境変数置換（`loadConfig()`）
- **persona / skill / agent ローダー**: .md ファイルからの階層的読み込みとグローバル/ローカル上書き
- 57 新規テスト追加（合計 132 テスト全パス）

## Architecture
```
src/loader/
├── types.ts            # WnConfig, Persona, Skill, AgentDef, LoaderError 等
├── frontmatter.ts      # parseFrontmatter() - 簡易 YAML frontmatter
├── config-loader.ts    # loadConfig() - JSON + deep merge + env var
├── persona-loader.ts   # loadPersonas() - .md → Persona
├── skill-loader.ts     # loadSkills() - SKILL.md → Skill
└── agent-loader.ts     # loadAgents() - agent .md → AgentDef
```

## Design Decisions
- 外部 YAML パーサー不使用（flat key-value + inline array のみ対応）
- deep merge は配列上書き（マージしない）で予測可能性を確保
- ENOENT は正常（空結果を返す）、パースエラーのみ err
- `as` キャスト禁止: `isNodeError()` 型ガード + `isPlainObject()` で型安全

## Test plan
- [x] frontmatter パーサーテスト（13件）
- [x] config ローダーテスト（19件）
- [x] persona ローダーテスト（8件）
- [x] skill ローダーテスト（8件）
- [x] agent ローダーテスト（7件）
- [x] index.ts re-export テスト（2件追加）
- [x] `npm test` — 132テスト全パス
- [x] `npm run typecheck` — 型エラーなし
- [x] `npm run build` — ビルド成功
- [x] `npm run lint` — ESLint エラーなし
- [x] `npm run format:check` — フォーマット統一

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)