### PR TITLE
feat: implement AgentLoop (#11)

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1,0 +1,203 @@
+import type { Result } from '../result.js'
+import { ok, err } from '../result.js'
+import type { Message, Tool } from '../providers/types.js'
+import type { AgentLoopHandler, AgentLoopOptions, AgentLoopState } from './types.js'
+
+const DEFAULT_MAX_TOOL_ROUNDS = 10
+
+/**
+ * AgentLoop — LLMProvider + ToolRegistry を接続する対話ループ
+ *
+ * step() で1回の対話ターンを処理し、
+ * run() で継続的ループを実行する。
+ */
+export class AgentLoop {
+  private readonly options: Required<
+    Pick<AgentLoopOptions, 'provider' | 'tools' | 'handler' | 'maxToolRounds'>
+  > &
+    Pick<AgentLoopOptions, 'signal'>
+
+  private state: AgentLoopState = 'idle'
+  private readonly messages: Message[] = []
+
+  constructor(opts: AgentLoopOptions) {
+    this.options = {
+      provider: opts.provider,
+      tools: opts.tools,
+      handler: opts.handler,
+      maxToolRounds: opts.maxToolRounds ?? DEFAULT_MAX_TOOL_ROUNDS,
+      signal: opts.signal,
+    }
+
+    if (opts.systemMessage !== undefined) {
+      this.messages.push({ role: 'system', content: opts.systemMessage })
+    }
+  }
+
+  /** 現在の状態 */
+  getState(): AgentLoopState {
+    return this.state
+  }
+
+  /** メッセージ履歴（読み取り専用） */
+  getMessages(): readonly Message[] {
+    return this.messages
+  }
+
+  /**
+   * 1回の対話ターンを処理する。
+   * ツール呼び出しがなくなるか maxToolRounds に達するまでループ。
+   */
+  async step(input: string): Promise<Result<string>> {
+    // abort チェック
+    if (this.options.signal?.aborted) {
+      return err('Aborted')
+    }
+
+    this.messages.push({ role: 'user', content: input })
+
+    const { provider, tools, handler, maxToolRounds } = this.options
+
+    // ToolDefinition[] → Tool[] 変換
+    const toolDefs = tools.list()
+    const llmTools: readonly Tool[] = toolDefs.map((td) => ({
+      name: td.name,
+      description: td.description,
+      parameters: td.parameters,
+    }))
+
+    let toolRound = 0
+
+    while (toolRound < maxToolRounds) {
+      // abort チェック
+      if (this.options.signal?.aborted) {
+        return err('Aborted')
+      }
+
+      await this.setState('thinking')
+
+      const llmResult = await provider.complete(this.messages, llmTools)
+
+      if (!llmResult.ok) {
+        await handler.onError(llmResult.error)
+        return err(llmResult.error)
+      }
+
+      const response = llmResult.data
+
+      // usage 通知
+      if (response.usage && handler.onUsage) {
+        await handler.onUsage(response.usage)
+      }
+
+      // ツール呼び出しなし → テキスト応答で終了
+      if (!response.toolCalls || response.toolCalls.length === 0) {
+        this.messages.push({ role: 'assistant', content: response.content })
+        await handler.onResponse(response.content)
+        await this.setState('idle')
+        return ok(response.content)
+      }
+
+      // ツール呼び出しあり
+      this.messages.push({
+        role: 'assistant',
+        content: response.content,
+        toolCalls: response.toolCalls,
+      })
+
+      // 中間テキストがあれば通知
+      if (response.content) {
+        await handler.onResponse(response.content)
+      }
+
+      // 各ツール呼び出しを順番に実行
+      for (const toolCall of response.toolCalls) {
+        // abort チェック
+        if (this.options.signal?.aborted) {
+          return err('Aborted')
+        }
+
+        const tool = tools.get(toolCall.name)
+
+        if (!tool) {
+          // 未登録ツール → エラーメッセージをフィードバック
+          const errorOutput = `Tool not found: ${toolCall.name}`
+          this.messages.push({
+            role: 'user',
+            content: errorOutput,
+            toolCallId: toolCall.id,
+            name: toolCall.name,
+          })
+          continue
+        }
+
+        await this.setState('tool_running')
+        await handler.onToolStart(toolCall.name, toolCall.arguments)
+
+        const result = await tool.execute(toolCall.arguments)
+
+        this.messages.push({
+          role: 'user',
+          content: result.output,
+          toolCallId: toolCall.id,
+          name: toolCall.name,
+        })
+
+        await handler.onToolEnd(toolCall.name, result)
+      }
+
+      toolRound++
+    }
+
+    // maxToolRounds 到達
+    const errorMsg = `Max tool rounds (${String(maxToolRounds)}) reached`
+    await handler.onError(errorMsg)
+    return err(errorMsg)
+  }
+
+  /**
+   * 継続的ループ。inputSource から入力を取得して step() を呼ぶ。
+   * AbortSignal または loopHook で終了。
+   */
+  async run(
+    inputSource: AsyncIterable<string>,
+    loopHook?: (loop: AgentLoop) => Promise<boolean>,
+  ): Promise<Result<void>> {
+    for await (const input of inputSource) {
+      // abort チェック
+      if (this.options.signal?.aborted) {
+        return err('Aborted')
+      }
+
+      await this.step(input)
+
+      // loopHook が true を返したら終了
+      if (loopHook) {
+        const shouldStop = await loopHook(this)
+        if (shouldStop) {
+          return ok(undefined)
+        }
+      }
+    }
+
+    return ok(undefined)
+  }
+
+  private async setState(newState: AgentLoopState): Promise<void> {
+    this.state = newState
+    await this.options.handler.onStateChange(newState)
+  }
+}
+
+/** テスト用のノーオペレーションハンドラ */
+export function createNoopHandler(): AgentLoopHandler {
+  const noop = (): void => {}
+  return {
+    onResponse: noop,
+    onToolStart: noop,
+    onToolEnd: noop,
+    onStateChange: noop,
+    onError: noop,
+    onUsage: noop,
+  }
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,3 +1,6 @@
+import type { LLMProvider, TokenUsage } from '../providers/types.js'
+import type { ToolRegistry, ToolResult } from '../tools/types.js'
+
 /**
  * サブエージェントのステータス
  */
@@ -33,4 +36,29 @@ export interface SubAgentRunner {
 
   /** サブエージェントを停止する */
   stop(id: string): Promise<void>
+}
+
+// --- AgentLoop 関連 ---
+
+/** AgentLoop の状態 */
+export type AgentLoopState = 'idle' | 'waiting_input' | 'thinking' | 'tool_running'
+
+/** AgentLoop イベントハンドラ */
+export interface AgentLoopHandler {
+  readonly onResponse: (content: string) => void | Promise<void>
+  readonly onToolStart: (name: string, args: Record<string, unknown>) => void | Promise<void>
+  readonly onToolEnd: (name: string, result: ToolResult) => void | Promise<void>
+  readonly onStateChange: (state: AgentLoopState) => void | Promise<void>
+  readonly onError: (error: string) => void | Promise<void>
+  readonly onUsage?: (usage: TokenUsage) => void | Promise<void>
+}
+
+/** AgentLoop コンストラクタオプション */
+export interface AgentLoopOptions {
+  readonly provider: LLMProvider
+  readonly tools: ToolRegistry
+  readonly handler: AgentLoopHandler
+  readonly systemMessage?: string
+  readonly maxToolRounds?: number
+  readonly signal?: AbortSignal
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,10 @@ export type { ShellConfig } from './tools/shell.js'
 
 // Agent types
 export type { SubAgentStatus, SubAgentHandle, AgentConfig, SubAgentRunner } from './agent/types.js'
+export type { AgentLoopState, AgentLoopHandler, AgentLoopOptions } from './agent/types.js'
+
+// AgentLoop
+export { AgentLoop, createNoopHandler } from './agent/agent-loop.js'
 
 // Loader types
 export type {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -12,6 +12,9 @@ export type JsonSchema = Record<string, unknown>
 export interface Message {
   readonly role: 'user' | 'assistant' | 'system'
   readonly content: string
+  readonly toolCallId?: string
+  readonly name?: string
+  readonly toolCalls?: readonly ToolCall[]
 }
 
 /** LLM に渡すツール定義 */

--- a/tests/agent/agent-loop.test.ts
+++ b/tests/agent/agent-loop.test.ts
@@ -1,0 +1,678 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { LLMResponse, Message, Tool, TokenUsage } from '../../src/providers/types.js'
+import type { ToolDefinition, ToolResult } from '../../src/tools/types.js'
+import { ToolRegistry } from '../../src/tools/types.js'
+import type { AgentLoopState } from '../../src/agent/types.js'
+import { AgentLoop, createNoopHandler } from '../../src/agent/agent-loop.js'
+import type { Result } from '../../src/result.js'
+import { ok, err } from '../../src/result.js'
+
+// ---------------------------------------------------------------------------
+// ヘルパー: モック LLMProvider を生成
+// ---------------------------------------------------------------------------
+type CompleteFn = (
+  messages: readonly Message[],
+  tools?: readonly Tool[],
+) => Promise<Result<LLMResponse>>
+
+function createMockProvider(): { complete: ReturnType<typeof vi.fn<CompleteFn>> } {
+  return {
+    complete: vi.fn<CompleteFn>(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ヘルパー: スパイ付き AgentLoopHandler を生成
+// ---------------------------------------------------------------------------
+function createSpyHandler(): {
+  onResponse: ReturnType<typeof vi.fn<(content: string) => void>>
+  onToolStart: ReturnType<typeof vi.fn<(name: string, args: Record<string, unknown>) => void>>
+  onToolEnd: ReturnType<typeof vi.fn<(name: string, result: ToolResult) => void>>
+  onStateChange: ReturnType<typeof vi.fn<(state: AgentLoopState) => void>>
+  onError: ReturnType<typeof vi.fn<(error: string) => void>>
+  onUsage: ReturnType<typeof vi.fn<(usage: TokenUsage) => void>>
+} {
+  return {
+    onResponse: vi.fn<(content: string) => void>(),
+    onToolStart: vi.fn<(name: string, args: Record<string, unknown>) => void>(),
+    onToolEnd: vi.fn<(name: string, result: ToolResult) => void>(),
+    onStateChange: vi.fn<(state: AgentLoopState) => void>(),
+    onError: vi.fn<(error: string) => void>(),
+    onUsage: vi.fn<(usage: TokenUsage) => void>(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ヘルパー: ダミー ToolDefinition を生成
+// ---------------------------------------------------------------------------
+function createDummyTool(
+  name: string,
+  executeFn?: (args: Record<string, unknown>) => Promise<ToolResult>,
+): ToolDefinition {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: {},
+    execute:
+      executeFn ??
+      ((): Promise<ToolResult> => Promise.resolve({ ok: true, output: `${name} done` })),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ヘルパー: AsyncIterable<string> を配列から生成
+// ---------------------------------------------------------------------------
+async function* arrayToAsyncIterable(items: string[]): AsyncIterable<string> {
+  for (const item of items) {
+    yield await Promise.resolve(item)
+  }
+}
+
+// ===========================================================================
+// テスト本体
+// ===========================================================================
+
+describe('AgentLoop', () => {
+  let mockProvider: ReturnType<typeof createMockProvider>
+  let tools: ToolRegistry
+  let handler: ReturnType<typeof createSpyHandler>
+
+  beforeEach(() => {
+    mockProvider = createMockProvider()
+    tools = new ToolRegistry()
+    handler = createSpyHandler()
+  })
+
+  // -------------------------------------------------------------------------
+  // constructor
+  // -------------------------------------------------------------------------
+  describe('constructor', () => {
+    it('デフォルトの maxToolRounds は 10', () => {
+      // maxToolRounds を指定せずに構築し、10 ラウンド目で打ち切られることを間接検証する。
+      // ここでは内部状態の確認が難しいため、step() で 10 回ツールを返して
+      // エラーになることで検証する（エラー/ガードセクションの test 14 で詳細検証）。
+      // constructor レベルではオプション省略時にエラーにならないことを検証。
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+      expect(loop).toBeDefined()
+      expect(loop.getState()).toBe('idle')
+    })
+
+    it('systemMessage ありの場合、messages 先頭に system メッセージ', () => {
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+        systemMessage: 'You are a helpful assistant.',
+      })
+      const messages = loop.getMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toStrictEqual({
+        role: 'system',
+        content: 'You are a helpful assistant.',
+      })
+    })
+
+    it('systemMessage なしの場合、messages は空', () => {
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+      const messages = loop.getMessages()
+      expect(messages).toHaveLength(0)
+    })
+
+    it('初期状態は idle', () => {
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+      expect(loop.getState()).toBe('idle')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // step() — basic path
+  // -------------------------------------------------------------------------
+  describe('step() — basic path', () => {
+    it('テキスト応答→ok(content) + onResponse', async () => {
+      mockProvider.complete.mockResolvedValueOnce(ok<LLMResponse>({ content: 'Hello, world!' }))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      const result = await loop.step('Hi')
+      expect(result).toStrictEqual(ok('Hello, world!'))
+      expect(handler.onResponse).toHaveBeenCalledWith('Hello, world!')
+      expect(handler.onResponse).toHaveBeenCalledTimes(1)
+    })
+
+    it('ユーザー入力と応答が messages 履歴に追加される', async () => {
+      mockProvider.complete.mockResolvedValueOnce(ok<LLMResponse>({ content: 'Reply 1' }))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      await loop.step('Input 1')
+      const messages = loop.getMessages()
+
+      // user メッセージ + assistant メッセージ
+      expect(messages).toHaveLength(2)
+      expect(messages[0]).toStrictEqual({ role: 'user', content: 'Input 1' })
+      expect(messages[1]).toStrictEqual({ role: 'assistant', content: 'Reply 1' })
+    })
+
+    it('usage があれば onUsage が呼ばれる', async () => {
+      const usage: TokenUsage = { inputTokens: 100, outputTokens: 50 }
+      mockProvider.complete.mockResolvedValueOnce(ok<LLMResponse>({ content: 'Response', usage }))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      await loop.step('Hello')
+      expect(handler.onUsage).toHaveBeenCalledWith(usage)
+      expect(handler.onUsage).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // step() — tool calls
+  // -------------------------------------------------------------------------
+  describe('step() — tool calls', () => {
+    it('ツール呼び出し→ツール実行→再度 LLM', async () => {
+      const echoTool = createDummyTool('echo', (args) =>
+        Promise.resolve({
+          ok: true,
+          output: `echoed: ${String(args['text'])}`,
+        }),
+      )
+      tools.register(echoTool)
+
+      // 1st call: LLM returns tool call
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({
+          content: '',
+          toolCalls: [{ id: 'tc-1', name: 'echo', arguments: { text: 'hello' } }],
+        }),
+      )
+      // 2nd call: LLM returns text after tool result
+      mockProvider.complete.mockResolvedValueOnce(ok<LLMResponse>({ content: 'Done echoing.' }))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      const result = await loop.step('Echo hello')
+      expect(result).toStrictEqual(ok('Done echoing.'))
+      expect(mockProvider.complete).toHaveBeenCalledTimes(2)
+    })
+
+    it('複数ツール呼び出しを順番に実行', async () => {
+      const executionOrder: string[] = []
+
+      const toolA = createDummyTool('toolA', () => {
+        executionOrder.push('toolA')
+        return Promise.resolve({ ok: true, output: 'A done' })
+      })
+      const toolB = createDummyTool('toolB', () => {
+        executionOrder.push('toolB')
+        return Promise.resolve({ ok: true, output: 'B done' })
+      })
+      tools.register(toolA)
+      tools.register(toolB)
+
+      // 1st call: LLM returns two tool calls
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({
+          content: '',
+          toolCalls: [
+            { id: 'tc-a', name: 'toolA', arguments: {} },
+            { id: 'tc-b', name: 'toolB', arguments: {} },
+          ],
+        }),
+      )
+      // 2nd call: LLM returns text
+      mockProvider.complete.mockResolvedValueOnce(ok<LLMResponse>({ content: 'Both done.' }))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      await loop.step('Run both')
+      expect(executionOrder).toStrictEqual(['toolA', 'toolB'])
+    })
+
+    it('ツール結果が toolCallId + name 付きで messages に追加', async () => {
+      const greetTool = createDummyTool('greet', () =>
+        Promise.resolve({
+          ok: true,
+          output: 'Greetings!',
+        }),
+      )
+      tools.register(greetTool)
+
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({
+          content: '',
+          toolCalls: [{ id: 'tc-greet', name: 'greet', arguments: {} }],
+        }),
+      )
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({ content: 'Greeting complete.' }),
+      )
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      await loop.step('Greet me')
+      const messages = loop.getMessages()
+
+      // Find the tool result message
+      const toolResultMsg = messages.find((m) => m.role === 'user' && m.toolCallId !== undefined)
+      if (toolResultMsg === undefined) {
+        expect.fail('Tool result message not found in messages')
+      }
+      expect(toolResultMsg.toolCallId).toBe('tc-greet')
+      expect(toolResultMsg.name).toBe('greet')
+      expect(toolResultMsg.content).toBe('Greetings!')
+    })
+
+    it('ツール呼び出し後にテキスト応答→ループ終了', async () => {
+      const calcTool = createDummyTool('calc', () =>
+        Promise.resolve({
+          ok: true,
+          output: '42',
+        }),
+      )
+      tools.register(calcTool)
+
+      // 1st call: tool call with accompanying text
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({
+          content: 'Let me calculate...',
+          toolCalls: [{ id: 'tc-calc', name: 'calc', arguments: {} }],
+        }),
+      )
+      // 2nd call: final text response (no tool calls) → loop ends
+      mockProvider.complete.mockResolvedValueOnce(ok<LLMResponse>({ content: 'The answer is 42.' }))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      const result = await loop.step('What is the answer?')
+      expect(result).toStrictEqual(ok('The answer is 42.'))
+      // onResponse should be called for both the intermediate text and final response
+      expect(handler.onResponse).toHaveBeenCalledWith('Let me calculate...')
+      expect(handler.onResponse).toHaveBeenCalledWith('The answer is 42.')
+    })
+
+    it('onToolStart / onToolEnd が正しい順序', async () => {
+      const callOrder: string[] = []
+
+      handler.onToolStart.mockImplementation((name: string) => {
+        callOrder.push(`start:${name}`)
+      })
+      handler.onToolEnd.mockImplementation((name: string) => {
+        callOrder.push(`end:${name}`)
+      })
+
+      const myTool = createDummyTool('myTool', () =>
+        Promise.resolve({
+          ok: true,
+          output: 'result',
+        }),
+      )
+      tools.register(myTool)
+
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({
+          content: '',
+          toolCalls: [{ id: 'tc-1', name: 'myTool', arguments: { x: 1 } }],
+        }),
+      )
+      mockProvider.complete.mockResolvedValueOnce(ok<LLMResponse>({ content: 'Finished.' }))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      await loop.step('Go')
+
+      expect(callOrder).toStrictEqual(['start:myTool', 'end:myTool'])
+      expect(handler.onToolStart).toHaveBeenCalledWith('myTool', { x: 1 })
+      expect(handler.onToolEnd).toHaveBeenCalledWith('myTool', { ok: true, output: 'result' })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // step() — error/guard
+  // -------------------------------------------------------------------------
+  describe('step() — error/guard', () => {
+    it('未登録ツール→エラーメッセージをツール結果として返す', async () => {
+      // LLM requests a tool that does not exist in the registry
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({
+          content: '',
+          toolCalls: [{ id: 'tc-unknown', name: 'nonexistent', arguments: {} }],
+        }),
+      )
+      // After the error tool result is fed back, LLM responds with text
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({ content: 'I could not find that tool.' }),
+      )
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      const result = await loop.step('Use nonexistent tool')
+      expect(result).toStrictEqual(ok('I could not find that tool.'))
+
+      // The tool result message should contain an error about the unknown tool
+      const messages = loop.getMessages()
+      const toolResultMsg = messages.find((m) => m.role === 'user' && m.toolCallId === 'tc-unknown')
+      if (toolResultMsg === undefined) {
+        expect.fail('Tool result message not found in messages')
+      }
+      expect(toolResultMsg.content).toContain('nonexistent')
+    })
+
+    it('maxToolRounds 到達→err', async () => {
+      const loopTool = createDummyTool('loopTool')
+      tools.register(loopTool)
+
+      // LLM always returns a tool call (never a plain text response)
+      mockProvider.complete.mockImplementation(() =>
+        Promise.resolve(
+          ok<LLMResponse>({
+            content: '',
+            toolCalls: [{ id: 'tc-loop', name: 'loopTool', arguments: {} }],
+          }),
+        ),
+      )
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+        maxToolRounds: 3,
+      })
+
+      const result = await loop.step('Loop forever')
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toBeDefined()
+      }
+      expect(handler.onError).toHaveBeenCalled()
+    })
+
+    it('LLM エラー→onError + err', async () => {
+      mockProvider.complete.mockResolvedValueOnce(err('LLM service unavailable'))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      const result = await loop.step('Hello')
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toBe('LLM service unavailable')
+      }
+      expect(handler.onError).toHaveBeenCalledWith('LLM service unavailable')
+    })
+
+    it('onStateChange が thinking → tool_running → thinking → idle の順', async () => {
+      const stateSequence: AgentLoopState[] = []
+      handler.onStateChange.mockImplementation((state: AgentLoopState) => {
+        stateSequence.push(state)
+      })
+
+      const simpleTool = createDummyTool('simpleTool')
+      tools.register(simpleTool)
+
+      // 1st: tool call
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({
+          content: '',
+          toolCalls: [{ id: 'tc-s', name: 'simpleTool', arguments: {} }],
+        }),
+      )
+      // 2nd: text response
+      mockProvider.complete.mockResolvedValueOnce(ok<LLMResponse>({ content: 'All done.' }))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      await loop.step('Do it')
+
+      expect(stateSequence).toStrictEqual(['thinking', 'tool_running', 'thinking', 'idle'])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // step() — abort
+  // -------------------------------------------------------------------------
+  describe('step() — abort', () => {
+    it("signal abort → err('Aborted')", async () => {
+      const controller = new AbortController()
+      controller.abort() // abort immediately
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+        signal: controller.signal,
+      })
+
+      const result = await loop.step('Hello')
+      expect(result).toStrictEqual(err('Aborted'))
+      // Provider should not have been called
+      expect(mockProvider.complete).not.toHaveBeenCalled()
+    })
+
+    it('ツール実行中の abort → 残りスキップ', async () => {
+      const controller = new AbortController()
+      const executedTools: string[] = []
+
+      const slowTool = createDummyTool('slowTool', () => {
+        executedTools.push('slowTool')
+        // Abort after this tool executes
+        controller.abort()
+        return Promise.resolve({ ok: true, output: 'slow done' })
+      })
+      const nextTool = createDummyTool('nextTool', () => {
+        executedTools.push('nextTool')
+        return Promise.resolve({ ok: true, output: 'next done' })
+      })
+      tools.register(slowTool)
+      tools.register(nextTool)
+
+      // LLM returns two tool calls; abort happens during first
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({
+          content: '',
+          toolCalls: [
+            { id: 'tc-slow', name: 'slowTool', arguments: {} },
+            { id: 'tc-next', name: 'nextTool', arguments: {} },
+          ],
+        }),
+      )
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+        signal: controller.signal,
+      })
+
+      const result = await loop.step('Run tools')
+      expect(result).toStrictEqual(err('Aborted'))
+      // slowTool was executed but nextTool should be skipped
+      expect(executedTools).toContain('slowTool')
+      expect(executedTools).not.toContain('nextTool')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // run()
+  // -------------------------------------------------------------------------
+  describe('run()', () => {
+    it('複数入力を順番に処理', async () => {
+      // Each input gets a simple text response
+      mockProvider.complete
+        .mockResolvedValueOnce(ok<LLMResponse>({ content: 'Reply 1' }))
+        .mockResolvedValueOnce(ok<LLMResponse>({ content: 'Reply 2' }))
+        .mockResolvedValueOnce(ok<LLMResponse>({ content: 'Reply 3' }))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      const inputSource = arrayToAsyncIterable(['Input 1', 'Input 2', 'Input 3'])
+      const result = await loop.run(inputSource)
+
+      expect(result).toStrictEqual(ok(undefined))
+      expect(mockProvider.complete).toHaveBeenCalledTimes(3)
+      expect(handler.onResponse).toHaveBeenCalledWith('Reply 1')
+      expect(handler.onResponse).toHaveBeenCalledWith('Reply 2')
+      expect(handler.onResponse).toHaveBeenCalledWith('Reply 3')
+    })
+
+    it('loopHook が true → 正常終了', async () => {
+      mockProvider.complete
+        .mockResolvedValueOnce(ok<LLMResponse>({ content: 'Reply 1' }))
+        .mockResolvedValueOnce(ok<LLMResponse>({ content: 'Reply 2' }))
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      let stepCount = 0
+      const loopHook = (): Promise<boolean> => {
+        stepCount++
+        // Return true (= stop) after the first step
+        return Promise.resolve(stepCount >= 1)
+      }
+
+      const inputSource = arrayToAsyncIterable(['Input 1', 'Input 2'])
+      const result = await loop.run(inputSource, loopHook)
+
+      expect(result).toStrictEqual(ok(undefined))
+      // Only one step should have been processed because loopHook returned true
+      expect(mockProvider.complete).toHaveBeenCalledTimes(1)
+    })
+
+    it('signal abort → err', async () => {
+      const controller = new AbortController()
+
+      mockProvider.complete.mockImplementation(() => {
+        // Abort after the first complete call
+        controller.abort()
+        return Promise.resolve(ok<LLMResponse>({ content: 'Reply' }))
+      })
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+        signal: controller.signal,
+      })
+
+      const inputSource = arrayToAsyncIterable(['Input 1', 'Input 2', 'Input 3'])
+      const result = await loop.run(inputSource)
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toBe('Aborted')
+      }
+    })
+
+    it('step エラーでもループ続行', async () => {
+      // 1st step: LLM error
+      mockProvider.complete.mockResolvedValueOnce(err('Temporary error'))
+      // 2nd step: success
+      mockProvider.complete.mockResolvedValueOnce(
+        ok<LLMResponse>({ content: 'Success on second try' }),
+      )
+
+      const loop = new AgentLoop({
+        provider: mockProvider,
+        tools,
+        handler,
+      })
+
+      const inputSource = arrayToAsyncIterable(['Input 1', 'Input 2'])
+      const result = await loop.run(inputSource)
+
+      expect(result).toStrictEqual(ok(undefined))
+      // Both inputs should have been processed
+      expect(mockProvider.complete).toHaveBeenCalledTimes(2)
+      expect(handler.onError).toHaveBeenCalledWith('Temporary error')
+      expect(handler.onResponse).toHaveBeenCalledWith('Success on second try')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createNoopHandler
+// ---------------------------------------------------------------------------
+describe('createNoopHandler', () => {
+  it('全コールバックが関数として存在する', () => {
+    const handler = createNoopHandler()
+    expect(typeof handler.onResponse).toBe('function')
+    expect(typeof handler.onToolStart).toBe('function')
+    expect(typeof handler.onToolEnd).toBe('function')
+    expect(typeof handler.onStateChange).toBe('function')
+    expect(typeof handler.onError).toBe('function')
+  })
+
+  it('呼び出してもエラーにならない', async () => {
+    const handler = createNoopHandler()
+    // All callbacks should be callable without throwing
+    await handler.onResponse('test')
+    await handler.onToolStart('tool', {})
+    await handler.onToolEnd('tool', { ok: true, output: 'out' })
+    await handler.onStateChange('idle')
+    await handler.onError('err')
+    if (handler.onUsage) {
+      await handler.onUsage({ inputTokens: 0, outputTokens: 0 })
+    }
+  })
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,6 +14,8 @@ import {
   loadPersonas,
   loadSkills,
   loadAgents,
+  AgentLoop,
+  createNoopHandler,
 } from '../src/index.js'
 import type { ShellConfig } from '../src/index.js'
 import type {
@@ -31,6 +33,9 @@ import type {
   SubAgentHandle,
   AgentConfig,
   SubAgentRunner,
+  AgentLoopState,
+  AgentLoopHandler,
+  AgentLoopOptions,
   WnConfig,
   ProviderConfig,
   McpConfig,
@@ -106,6 +111,13 @@ describe('wn-core', () => {
     expect(undefined as LLMProvider | undefined).toBeUndefined()
     expect(undefined as ToolDefinition | undefined).toBeUndefined()
     expect(undefined as SubAgentRunner | undefined).toBeUndefined()
+
+    // AgentLoop 関連型
+    const loopState: AgentLoopState = 'idle'
+    expect(loopState).toBe('idle')
+
+    expect(undefined as AgentLoopHandler | undefined).toBeUndefined()
+    expect(undefined as AgentLoopOptions | undefined).toBeUndefined()
   })
 
   it('組み込みツールファクトリがエクスポートされている', () => {
@@ -128,6 +140,14 @@ describe('wn-core', () => {
     // ShellConfig 型が利用可能
     const config: ShellConfig = getShellConfig('linux')
     expect(config.shell).toBe('/bin/sh')
+  })
+
+  it('AgentLoop と createNoopHandler がエクスポートされている', () => {
+    expect(typeof AgentLoop).toBe('function')
+    expect(typeof createNoopHandler).toBe('function')
+
+    const handler = createNoopHandler()
+    expect(typeof handler.onResponse).toBe('function')
   })
 
   it('Loader 関数がエクスポートされている', () => {


### PR DESCRIPTION
## Summary

- **AgentLoop クラス** を実装: LLMProvider + ToolRegistry を接続し「入力→LLM呼び出し→ツール実行→応答」の対話ループを実現
- **step()** で1回の対話ターン処理、**run()** で継続的ループを提供
- **Message 型拡張**: `toolCallId`, `name`, `toolCalls` オプショナルフィールドを追加（既存への破壊的変更なし）
- **AgentLoopHandler** コールバックオブジェクトで型安全なイベント通知
- **AbortSignal** による中断制御と **maxToolRounds** (デフォルト10) による無限ループ防止

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/agent/agent-loop.ts` | AgentLoop クラス + createNoopHandler（新規） |
| `src/agent/types.ts` | AgentLoopState, AgentLoopHandler, AgentLoopOptions 型追加 |
| `src/providers/types.ts` | Message にオプショナルフィールド追加 |
| `src/index.ts` | re-export 追加 |
| `tests/agent/agent-loop.test.ts` | 24テスト（新規） |
| `tests/index.test.ts` | re-export 検証追加 |

## Test plan

- [x] `npm test` — 全テスト通過（既存132件 + 新規24件 = 156件）
- [x] `npm run typecheck` — 型エラーなし
- [x] `npm run build` — ビルド成功
- [x] `npm run lint` — ESLint エラーなし
- [x] `npm run format:check` — Prettier フォーマット統一

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)