### PR TITLE
ci: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint & Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm run lint
+
+      - run: npm run format:check
+
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run test:coverage
+
+      # TODO: Codecov upload (要トークン設定後に有効化)
+      # - uses: codecov/codecov-action@v4
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage/cobertura-coverage.xml
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build


### PR DESCRIPTION
## Summary

- GitHub Actions CI ワークフローを追加（`.github/workflows/ci.yml`）
- 3 ジョブ並列実行で高速フィードバック:
  - **lint**: typecheck + eslint + prettier（Node 22）
  - **test**: vitest with coverage（Node 20/22 マトリクス）
  - **build**: tsup ビルド検証（Node 22）
- `npm ci` + built-in cache で再現性あるインストール
- `concurrency` 設定で同一ブランチの重複実行をキャンセル
- Codecov はコメントで準備済み（トークン設定後に有効化可能）

Closes #13

## Test plan

- [ ] GitHub Actions タブで CI が正常に動作することを確認
- [ ] lint ジョブ: typecheck, eslint, format:check が全てパス
- [ ] test ジョブ: Node 20 と Node 22 の両方でテストがパス
- [ ] build ジョブ: tsup ビルドが成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)