### PR TITLE
chore: add .gitattributes for consistent LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Auto detect text files and normalize line endings to LF
+* text=auto eol=lf
+
+# Explicitly declare text files
+*.ts text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.toml text eol=lf
+
+# Denote binary files
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary


### PR DESCRIPTION
## Summary

- `.gitattributes` を追加して全テキストファイルの line ending を LF に統一
- Windows 環境での CRLF 変換警告を解消

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)