### PR TITLE
feat: implement MCP Client module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@google/generative-ai": "^0.24.1",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "openai": "^6.25.0"
       },
       "devDependencies": {
@@ -698,6 +699,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -788,6 +801,68 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1567,6 +1642,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1607,6 +1695,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1646,6 +1773,30 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
@@ -1675,6 +1826,15 @@
         "esbuild": ">=0.18"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1683,6 +1843,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -1738,11 +1927,67 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1757,7 +2002,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1778,12 +2022,80 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1826,6 +2138,12 @@
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2018,6 +2336,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2028,11 +2376,71 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2048,6 +2456,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2078,6 +2502,27 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -2130,6 +2575,24 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2143,6 +2606,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2171,6 +2680,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2181,12 +2702,81 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
+      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2206,6 +2796,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-extglob": {
@@ -2231,11 +2845,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -2275,6 +2894,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {
@@ -2320,6 +2948,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2436,6 +3070,61 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -2469,7 +3158,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -2510,14 +3198,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obug": {
@@ -2530,6 +3238,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/openai": {
       "version": "6.25.0",
@@ -2602,6 +3331,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2616,10 +3354,19 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -2657,6 +3404,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -2769,6 +3525,19 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2777,6 +3546,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/readdirp": {
@@ -2791,6 +3599,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2858,6 +3675,28 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2871,11 +3710,61 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2888,10 +3777,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -2927,6 +3887,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -3033,6 +4002,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tree-kill": {
@@ -3157,6 +4135,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3209,6 +4201,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3217,6 +4218,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -3386,7 +4396,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3425,6 +4434,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -3436,6 +4451,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@google/generative-ai": "^0.24.1",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "openai": "^6.25.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,10 @@ export type {
   LoaderErrorCode,
 } from './loader/types.js'
 
+// MCP
+export type { McpConnection, McpManager } from './mcp/types.js'
+export { createMcpManager } from './mcp/client.js'
+
 // Loader functions
 export { parseFrontmatter } from './loader/frontmatter.js'
 export { loadConfig } from './loader/config-loader.js'

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,0 +1,162 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import type { Result } from '../result.js'
+import { ok, err } from '../result.js'
+import type { McpConfig, McpServerConfig } from '../loader/types.js'
+import type { ToolDefinition, ToolResult } from '../tools/types.js'
+import type { McpConnection, McpManager } from './types.js'
+
+/**
+ * MCP サーバー1台に接続し、ツール定義を取得する。
+ *
+ * @returns 成功時は McpConnection、失敗時は Error
+ */
+async function connectServer(serverConfig: McpServerConfig): Promise<Result<McpConnection>> {
+  const client = new Client({ name: 'wn-core', version: '0.1.0' })
+
+  const transport = new StdioClientTransport({
+    command: serverConfig.command,
+    args: [...serverConfig.args],
+  })
+
+  try {
+    await client.connect(transport)
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e)
+    return err(`Failed to connect to MCP server "${serverConfig.name}": ${message}`)
+  }
+
+  let tools: ToolDefinition[]
+  try {
+    const listResult = await client.listTools()
+    tools = listResult.tools.map((mcpTool) => wrapMcpTool(client, serverConfig.name, mcpTool))
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e)
+    await client.close().catch(() => {})
+    return err(`Failed to list tools from MCP server "${serverConfig.name}": ${message}`)
+  }
+
+  const connection: McpConnection = {
+    serverName: serverConfig.name,
+    tools,
+    close: async (): Promise<void> => {
+      await client.close()
+    },
+  }
+
+  return ok(connection)
+}
+
+/** content 配列からテキストを抽出する型ガード */
+function isTextContent(item: unknown): item is { type: 'text'; text: string } {
+  if (typeof item !== 'object' || item === null) return false
+  if (!('type' in item) || !('text' in item)) return false
+  return item.type === 'text' && typeof item.text === 'string'
+}
+
+/** CallToolResult の content 配列から最初のテキストを抽出する */
+function extractTextFromContent(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return ''
+  }
+  const textItem = content.find(isTextContent)
+  return textItem?.text ?? ''
+}
+
+/** MCP SDK の Tool 型（部分型） */
+interface McpToolDef {
+  readonly name: string
+  readonly description?: string
+  readonly inputSchema: Record<string, unknown>
+}
+
+/**
+ * MCP SDK の Tool → wn-core の ToolDefinition に変換する。
+ *
+ * - ツール名に `{serverName}__{toolName}` プレフィクスを付与
+ * - execute() は client.callTool() を元の名前で呼び出す
+ */
+function wrapMcpTool(client: Client, serverName: string, mcpTool: McpToolDef): ToolDefinition {
+  const originalName = mcpTool.name
+  const prefixedName = `${serverName}__${originalName}`
+
+  return {
+    name: prefixedName,
+    description: mcpTool.description ?? '',
+    parameters: mcpTool.inputSchema,
+    execute: async (args: Record<string, unknown>): Promise<ToolResult> => {
+      try {
+        const result = await client.callTool({
+          name: originalName,
+          arguments: args,
+        })
+
+        const output = extractTextFromContent(result.content)
+
+        if (result.isError === true) {
+          return { ok: false, output, error: output }
+        }
+
+        return { ok: true, output }
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e)
+        return { ok: false, output: '', error: message }
+      }
+    },
+  }
+}
+
+/**
+ * McpManager を生成するファクトリ関数。
+ *
+ * config.servers の各 MCP サーバーに対して stdio 接続を行い、
+ * ツール定義を取得する。
+ */
+export function createMcpManager(config: McpConfig): McpManager {
+  let connections: McpConnection[] = []
+
+  return {
+    async connectAll(): Promise<Result<readonly McpConnection[]>> {
+      const servers = config.servers
+
+      if (servers.length === 0) {
+        return ok([])
+      }
+
+      const results = await Promise.allSettled(
+        servers.map((serverConfig) => connectServer(serverConfig)),
+      )
+
+      const succeeded: McpConnection[] = []
+      const errors: string[] = []
+
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          if (result.value.ok) {
+            succeeded.push(result.value.data)
+          } else {
+            errors.push(result.value.error)
+          }
+        } else {
+          errors.push(
+            result.reason instanceof Error ? result.reason.message : String(result.reason),
+          )
+        }
+      }
+
+      // 全サーバー失敗 → err
+      if (succeeded.length === 0 && errors.length > 0) {
+        return err(`All MCP servers failed to connect: ${errors.join('; ')}`)
+      }
+
+      connections = succeeded
+      return ok(succeeded)
+    },
+
+    async closeAll(): Promise<void> {
+      const closing = connections.map((conn) => conn.close().catch(() => {}))
+      await Promise.all(closing)
+      connections = []
+    },
+  }
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,17 @@
+import type { Result } from '../result.js'
+import type { ToolDefinition } from '../tools/types.js'
+
+/** MCP 接続1本分のハンドル */
+export interface McpConnection {
+  readonly serverName: string
+  readonly tools: readonly ToolDefinition[]
+  close(): Promise<void>
+}
+
+/** MCP マネージャー — 複数サーバーの接続を一括管理 */
+export interface McpManager {
+  /** 全サーバーに接続し、ツール定義を取得 */
+  connectAll(): Promise<Result<readonly McpConnection[]>>
+  /** 全接続をクローズ */
+  closeAll(): Promise<void>
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -20,6 +20,7 @@ import {
   createOpenAIProvider,
   createOllamaProvider,
   createGeminiProvider,
+  createMcpManager,
 } from '../src/index.js'
 import type { ShellConfig } from '../src/index.js'
 import type {
@@ -45,6 +46,8 @@ import type {
   ProviderConfig,
   McpConfig,
   McpServerConfig,
+  McpConnection,
+  McpManager,
   Persona,
   Skill,
   AgentDef,
@@ -168,6 +171,14 @@ describe('wn-core', () => {
     expect(typeof createOpenAIProvider).toBe('function')
     expect(typeof createOllamaProvider).toBe('function')
     expect(typeof createGeminiProvider).toBe('function')
+  })
+
+  it('MCP Client がエクスポートされている', () => {
+    expect(typeof createMcpManager).toBe('function')
+
+    // 型がインポート可能であることを検証
+    expect(undefined as McpConnection | undefined).toBeUndefined()
+    expect(undefined as McpManager | undefined).toBeUndefined()
   })
 
   it('StreamChunk 型がコンパイル時に利用可能（型チェック用）', () => {

--- a/tests/mcp/client.test.ts
+++ b/tests/mcp/client.test.ts
@@ -1,0 +1,577 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import type { McpConfig, McpServerConfig } from '../../src/loader/types.js'
+import { ToolRegistry } from '../../src/tools/types.js'
+import type { ToolDefinition, ToolResult } from '../../src/tools/types.js'
+
+// --- MCP SDK モック ---
+
+interface MockClientInstance {
+  connect: Mock
+  listTools: Mock
+  callTool: Mock
+  close: Mock
+}
+
+/** MCP SDK の Tool 型を模倣 */
+interface MockMcpTool {
+  name: string
+  description?: string
+  inputSchema: {
+    type: 'object'
+    properties?: Record<string, object>
+    required?: string[]
+  }
+}
+
+/** MCP SDK の CallToolResult 型を模倣 */
+interface MockCallToolResult {
+  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>
+  isError?: boolean
+}
+
+/**
+ * 事前設定用のモックインスタンス配列。
+ * Client コンストラクタが呼ばれるたびに、先頭から1つずつ消費される（FIFO）。
+ */
+let mockClientInstances: MockClientInstance[] = []
+let nextMockIndex = 0
+
+/** 新しい mockClient インスタンスを作成し、配列に追加して返す */
+function createMockClientInstance(): MockClientInstance {
+  const instance: MockClientInstance = {
+    connect: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    listTools: vi.fn<() => Promise<{ tools: MockMcpTool[] }>>().mockResolvedValue({ tools: [] }),
+    callTool: vi
+      .fn<() => Promise<MockCallToolResult>>()
+      .mockResolvedValue({ content: [{ type: 'text', text: '' }] }),
+    close: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  }
+  mockClientInstances.push(instance)
+  return instance
+}
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
+  return {
+    Client: class MockClient {
+      connect: Mock
+      listTools: Mock
+      callTool: Mock
+      close: Mock
+      constructor(_info: { name: string; version: string }) {
+        void _info
+        const inst = mockClientInstances[nextMockIndex]
+        if (!inst) {
+          throw new Error(`No mock instance at index ${String(nextMockIndex)}`)
+        }
+        nextMockIndex++
+        this.connect = inst.connect
+        this.listTools = inst.listTools
+        this.callTool = inst.callTool
+        this.close = inst.close
+      }
+    },
+  }
+})
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => {
+  return {
+    StdioClientTransport: class MockStdioClientTransport {
+      command: string
+      args: string[]
+      constructor(opts: { command: string; args?: string[] }) {
+        this.command = opts.command
+        this.args = opts.args ?? []
+      }
+    },
+  }
+})
+
+// SUT は mock 設定後にインポート
+const { createMcpManager } = await import('../../src/mcp/client.js')
+
+// --- ヘルパー ---
+
+function makeServerConfig(name: string, command = 'npx', args: string[] = []): McpServerConfig {
+  return { name, command, args }
+}
+
+function makeMcpConfig(servers: McpServerConfig[]): McpConfig {
+  return { servers }
+}
+
+function makeMcpTool(
+  name: string,
+  description?: string,
+  properties?: Record<string, object>,
+  required?: string[],
+): MockMcpTool {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: 'object',
+      properties: properties ?? {},
+      required: required ?? [],
+    },
+  }
+}
+
+function createDummyTool(name: string, description = `${name} tool`): ToolDefinition {
+  return {
+    name,
+    description,
+    parameters: {},
+    execute: (): Promise<ToolResult> => Promise.resolve({ ok: true, output: `${name} executed` }),
+  }
+}
+
+// --- テスト ---
+
+describe('MCP Client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockClientInstances = []
+    nextMockIndex = 0
+  })
+
+  // ====================================================================
+  // 1. createMcpManager
+  // ====================================================================
+  describe('createMcpManager', () => {
+    it('servers: [] で空の McpManager を返す', () => {
+      const manager = createMcpManager(makeMcpConfig([]))
+      expect(manager).toBeDefined()
+      expect(manager).toHaveProperty('connectAll')
+      expect(manager).toHaveProperty('closeAll')
+    })
+
+    it('有効な config で McpManager を返す', () => {
+      const config = makeMcpConfig([
+        makeServerConfig('server-a', 'npx', ['-y', '@example/mcp-server']),
+        makeServerConfig('server-b', 'node', ['server.js']),
+      ])
+      const manager = createMcpManager(config)
+      expect(manager).toBeDefined()
+      expect(manager).toHaveProperty('connectAll')
+      expect(manager).toHaveProperty('closeAll')
+    })
+  })
+
+  // ====================================================================
+  // 2. connectAll — 接続
+  // ====================================================================
+  describe('connectAll — 接続', () => {
+    it('1サーバー接続成功 → ok + McpConnection 1件', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({ tools: [] })
+
+      const manager = createMcpManager(
+        makeMcpConfig([makeServerConfig('alpha', 'npx', ['-y', 'alpha-server'])]),
+      )
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toHaveLength(1)
+        expect(result.data[0]?.serverName).toBe('alpha')
+      }
+    })
+
+    it('複数サーバー接続成功 → ok + McpConnection 複数件', async () => {
+      const inst1 = createMockClientInstance()
+      inst1.listTools.mockResolvedValue({ tools: [] })
+      const inst2 = createMockClientInstance()
+      inst2.listTools.mockResolvedValue({ tools: [] })
+      const inst3 = createMockClientInstance()
+      inst3.listTools.mockResolvedValue({ tools: [] })
+
+      const config = makeMcpConfig([
+        makeServerConfig('server-a', 'npx', ['a']),
+        makeServerConfig('server-b', 'npx', ['b']),
+        makeServerConfig('server-c', 'npx', ['c']),
+      ])
+      const manager = createMcpManager(config)
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toHaveLength(3)
+        const names = result.data.map((c) => c.serverName)
+        expect(names).toContain('server-a')
+        expect(names).toContain('server-b')
+        expect(names).toContain('server-c')
+      }
+    })
+
+    it('1サーバーのみで接続失敗 → err', async () => {
+      const inst = createMockClientInstance()
+      inst.connect.mockRejectedValue(new Error('Connection refused'))
+
+      const manager = createMcpManager(
+        makeMcpConfig([makeServerConfig('broken', 'npx', ['broken-server'])]),
+      )
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toBeDefined()
+      }
+    })
+
+    it('部分失敗（2サーバー中1つ成功）→ ok + 成功分のみ', async () => {
+      const successInst = createMockClientInstance()
+      successInst.listTools.mockResolvedValue({ tools: [] })
+
+      const failInst = createMockClientInstance()
+      failInst.connect.mockRejectedValue(new Error('Connection refused'))
+
+      const config = makeMcpConfig([
+        makeServerConfig('good-server', 'npx', ['good']),
+        makeServerConfig('bad-server', 'npx', ['bad']),
+      ])
+      const manager = createMcpManager(config)
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toHaveLength(1)
+        expect(result.data[0]?.serverName).toBe('good-server')
+      }
+    })
+
+    it('全サーバー失敗 → err', async () => {
+      const fail1 = createMockClientInstance()
+      fail1.connect.mockRejectedValue(new Error('Timeout'))
+
+      const fail2 = createMockClientInstance()
+      fail2.connect.mockRejectedValue(new Error('Connection refused'))
+
+      const config = makeMcpConfig([
+        makeServerConfig('server-x', 'npx', ['x']),
+        makeServerConfig('server-y', 'npx', ['y']),
+      ])
+      const manager = createMcpManager(config)
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toBeDefined()
+      }
+    })
+
+    it('servers: [] で connectAll → ok + 空配列', async () => {
+      const manager = createMcpManager(makeMcpConfig([]))
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toHaveLength(0)
+      }
+    })
+  })
+
+  // ====================================================================
+  // 3. ツール定義変換
+  // ====================================================================
+  describe('ツール定義変換', () => {
+    it('MCP ツール → ToolDefinition に正しく変換される', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({
+        tools: [makeMcpTool('scan', 'Run a scan', { target: { type: 'string' } }, ['target'])],
+      })
+
+      const manager = createMcpManager(
+        makeMcpConfig([makeServerConfig('sec-tools', 'npx', ['sec'])]),
+      )
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        const conn = result.data[0]
+        if (!conn) throw new Error('expected connection')
+        expect(conn.tools).toHaveLength(1)
+
+        const tool = conn.tools[0]
+        if (!tool) throw new Error('expected tool')
+        expect(tool).toHaveProperty('name')
+        expect(tool).toHaveProperty('description')
+        expect(tool).toHaveProperty('parameters')
+        expect(tool).toHaveProperty('execute')
+      }
+    })
+
+    it('ツール名にサーバー名プレフィクスが付く (serverName__toolName)', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({
+        tools: [makeMcpTool('run_scan', 'Run scan')],
+      })
+
+      const manager = createMcpManager(
+        makeMcpConfig([makeServerConfig('nmap', 'npx', ['nmap-server'])]),
+      )
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        const tool = result.data[0]?.tools[0]
+        if (!tool) throw new Error('expected tool')
+        expect(tool.name).toBe('nmap__run_scan')
+      }
+    })
+
+    it('description が引き継がれる（未定義の場合は空文字）', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({
+        tools: [makeMcpTool('with_desc', 'This tool does something'), makeMcpTool('no_desc')],
+      })
+
+      const manager = createMcpManager(makeMcpConfig([makeServerConfig('srv', 'npx', ['srv'])]))
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        const conn = result.data[0]
+        if (!conn) throw new Error('expected connection')
+        expect(conn.tools).toHaveLength(2)
+
+        const toolWithDesc = conn.tools.find((t) => t.name === 'srv__with_desc')
+        const toolNoDesc = conn.tools.find((t) => t.name === 'srv__no_desc')
+
+        expect(toolWithDesc?.description).toBe('This tool does something')
+        expect(toolNoDesc?.description).toBe('')
+      }
+    })
+
+    it('inputSchema が parameters にマッピングされる', async () => {
+      const inst = createMockClientInstance()
+      const inputSchema = {
+        type: 'object' as const,
+        properties: {
+          host: { type: 'string', description: 'Target host' },
+          port: { type: 'number', description: 'Target port' },
+        },
+        required: ['host'],
+      }
+      inst.listTools.mockResolvedValue({
+        tools: [{ name: 'connect', description: 'Connect to host', inputSchema }],
+      })
+
+      const manager = createMcpManager(makeMcpConfig([makeServerConfig('net', 'npx', ['net'])]))
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        const tool = result.data[0]?.tools[0]
+        if (!tool) throw new Error('expected tool')
+        expect(tool.parameters).toStrictEqual(inputSchema)
+      }
+    })
+
+    it('ツールなしサーバー → 空配列の tools', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({ tools: [] })
+
+      const manager = createMcpManager(
+        makeMcpConfig([makeServerConfig('empty-srv', 'npx', ['empty'])]),
+      )
+      const result = await manager.connectAll()
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        const conn = result.data[0]
+        if (!conn) throw new Error('expected connection')
+        expect(conn.tools).toStrictEqual([])
+      }
+    })
+  })
+
+  // ====================================================================
+  // 4. ツール実行 execute
+  // ====================================================================
+  describe('ツール実行 execute', () => {
+    it('execute() が client.callTool() をプレフィクスなしの元の名前で呼ぶ', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({
+        tools: [makeMcpTool('do_thing', 'Do a thing', { input: { type: 'string' } })],
+      })
+      inst.callTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'done' }],
+      })
+
+      const manager = createMcpManager(makeMcpConfig([makeServerConfig('my-srv', 'npx', ['srv'])]))
+      const connectResult = await manager.connectAll()
+      if (!connectResult.ok) throw new Error('connectAll failed')
+
+      const tool = connectResult.data[0]?.tools[0]
+      if (!tool) throw new Error('expected tool')
+
+      expect(tool.name).toBe('my-srv__do_thing')
+      await tool.execute({ input: 'hello' })
+
+      expect(inst.callTool).toHaveBeenCalledWith({
+        name: 'do_thing',
+        arguments: { input: 'hello' },
+      })
+    })
+
+    it('成功結果 → { ok: true, output: "result text" }', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({
+        tools: [makeMcpTool('echo', 'Echo tool')],
+      })
+      inst.callTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'echoed back' }],
+      })
+
+      const manager = createMcpManager(makeMcpConfig([makeServerConfig('util', 'npx', ['util'])]))
+      const connectResult = await manager.connectAll()
+      if (!connectResult.ok) throw new Error('connectAll failed')
+
+      const tool = connectResult.data[0]?.tools[0]
+      if (!tool) throw new Error('expected tool')
+
+      const execResult = await tool.execute({})
+
+      expect(execResult).toStrictEqual({ ok: true, output: 'echoed back' })
+    })
+
+    it('エラー結果 (isError: true) → { ok: false, output, error }', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({
+        tools: [makeMcpTool('fail_tool', 'A tool that fails')],
+      })
+      inst.callTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'something went wrong' }],
+        isError: true,
+      })
+
+      const manager = createMcpManager(makeMcpConfig([makeServerConfig('err-srv', 'npx', ['err'])]))
+      const connectResult = await manager.connectAll()
+      if (!connectResult.ok) throw new Error('connectAll failed')
+
+      const tool = connectResult.data[0]?.tools[0]
+      if (!tool) throw new Error('expected tool')
+
+      const execResult = await tool.execute({})
+
+      expect(execResult).toStrictEqual({
+        ok: false,
+        output: 'something went wrong',
+        error: 'something went wrong',
+      })
+    })
+
+    it('client.callTool() が例外 → { ok: false, output: "", error }', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({
+        tools: [makeMcpTool('crash_tool', 'A tool that crashes')],
+      })
+      inst.callTool.mockRejectedValue(new Error('Transport error'))
+
+      const manager = createMcpManager(
+        makeMcpConfig([makeServerConfig('crash-srv', 'npx', ['crash'])]),
+      )
+      const connectResult = await manager.connectAll()
+      if (!connectResult.ok) throw new Error('connectAll failed')
+
+      const tool = connectResult.data[0]?.tools[0]
+      if (!tool) throw new Error('expected tool')
+
+      const execResult = await tool.execute({})
+
+      expect(execResult).toStrictEqual({
+        ok: false,
+        output: '',
+        error: 'Transport error',
+      })
+    })
+  })
+
+  // ====================================================================
+  // 5. closeAll
+  // ====================================================================
+  describe('closeAll', () => {
+    it('全接続が正しくクローズされる', async () => {
+      const inst1 = createMockClientInstance()
+      inst1.listTools.mockResolvedValue({ tools: [] })
+      const inst2 = createMockClientInstance()
+      inst2.listTools.mockResolvedValue({ tools: [] })
+
+      const config = makeMcpConfig([
+        makeServerConfig('srv-1', 'npx', ['1']),
+        makeServerConfig('srv-2', 'npx', ['2']),
+      ])
+      const manager = createMcpManager(config)
+      const result = await manager.connectAll()
+      expect(result.ok).toBe(true)
+
+      await manager.closeAll()
+
+      expect(inst1.close).toHaveBeenCalledOnce()
+      expect(inst2.close).toHaveBeenCalledOnce()
+    })
+
+    it('接続前に closeAll() を呼んでもエラーにならない', async () => {
+      const manager = createMcpManager(makeMcpConfig([makeServerConfig('srv', 'npx', ['srv'])]))
+      await expect(manager.closeAll()).resolves.toBeUndefined()
+    })
+  })
+
+  // ====================================================================
+  // 6. ToolRegistry 統合
+  // ====================================================================
+  describe('ToolRegistry 統合', () => {
+    it('MCP ツールを registry.registerMcp() で登録できる', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({
+        tools: [makeMcpTool('scan_ports', 'Scan ports on a target')],
+      })
+
+      const manager = createMcpManager(makeMcpConfig([makeServerConfig('nmap', 'npx', ['nmap'])]))
+      const result = await manager.connectAll()
+      if (!result.ok) throw new Error('connectAll failed')
+
+      const registry = new ToolRegistry()
+      for (const conn of result.data) {
+        for (const tool of conn.tools) {
+          const regResult = registry.registerMcp(tool)
+          expect(regResult.ok).toBe(true)
+        }
+      }
+
+      const registered = registry.get('nmap__scan_ports')
+      expect(registered).toBeDefined()
+      expect(registered?.name).toBe('nmap__scan_ports')
+      expect(registered?.description).toBe('Scan ports on a target')
+    })
+
+    it('ビルトインと MCP のツール名が同じ場合、registry.get() はビルトイン優先', async () => {
+      const inst = createMockClientInstance()
+      inst.listTools.mockResolvedValue({
+        tools: [makeMcpTool('read', 'MCP read tool')],
+      })
+
+      const manager = createMcpManager(makeMcpConfig([makeServerConfig('srv', 'npx', ['srv'])]))
+      const result = await manager.connectAll()
+      if (!result.ok) throw new Error('connectAll failed')
+
+      const registry = new ToolRegistry()
+
+      // ビルトインとして同名を先に登録
+      const builtinTool = createDummyTool('srv__read', 'builtin version')
+      registry.register(builtinTool)
+
+      // MCP ツールとして同名を登録
+      for (const conn of result.data) {
+        for (const tool of conn.tools) {
+          registry.registerMcp(tool)
+        }
+      }
+
+      // ビルトインが優先される
+      const found = registry.get('srv__read')
+      expect(found).toBeDefined()
+      expect(found?.description).toBe('builtin version')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `@modelcontextprotocol/sdk` を使用した MCP Client モジュールを実装
- `createMcpManager(config)` ファクトリで複数 MCP サーバーへの stdio 接続を一括管理
- ツール名衝突防止のため `{serverName}__{toolName}` プレフィクス付与
- 部分成功戦略: `Promise.allSettled()` で一部サーバー失敗時も残りは利用可能
- `wrapMcpTool()` アダプタで MCP SDK の Tool → wn-core の `ToolDefinition` に変換

## 変更ファイル

| ファイル | 操作 |
|---------|------|
| `src/mcp/types.ts` | 新規 — McpConnection, McpManager 型定義 |
| `src/mcp/client.ts` | 新規 — createMcpManager, wrapMcpTool 実装 |
| `tests/mcp/client.test.ts` | 新規 — 21テストケース |
| `src/index.ts` | MCP エクスポート追加 |
| `tests/index.test.ts` | MCP エクスポートテスト追加 |
| `package.json` | `@modelcontextprotocol/sdk` 依存追加 |

## Test plan

- [x] 全 239 テスト通過
- [x] typecheck 通過
- [x] lint 通過
- [x] format:check 通過
- [x] build 通過
- [x] Semgrep スキャン: 0 findings

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)