### PR TITLE
feat: SubAgentRunner (Worker Threads) 実装

### DIFF
--- a/src/agent/sub-agent-runner.ts
+++ b/src/agent/sub-agent-runner.ts
@@ -1,0 +1,209 @@
+/**
+ * サブエージェントランナー
+ *
+ * AgentConfig から SubAgentWorkerData を解決する純粋関数と、
+ * Worker メッセージの型ガードを提供する。
+ */
+import { randomUUID } from 'node:crypto'
+import { Worker } from 'node:worker_threads'
+import type { Result } from '../result.js'
+import { ok, err } from '../result.js'
+import type {
+  AgentConfig,
+  SubAgentHandle,
+  SubAgentRunner,
+  SubAgentRunnerOptions,
+  SubAgentStatus,
+  SubAgentWorkerData,
+  WorkerMessage,
+} from './types.js'
+import type { Persona, Skill, WnConfig } from '../loader/types.js'
+
+/**
+ * AgentConfig と各種マスターデータから SubAgentWorkerData を組み立てる。
+ *
+ * persona / skills / provider いずれかの解決に失敗した場合は err を返す。
+ */
+export function resolveWorkerData(
+  id: string,
+  agentConfig: AgentConfig,
+  wnConfig: WnConfig,
+  personas: ReadonlyMap<string, Persona>,
+  skills: ReadonlyMap<string, Skill>,
+): Result<SubAgentWorkerData> {
+  // 1. Persona の解決
+  const persona = personas.get(agentConfig.persona)
+  if (persona === undefined) {
+    return err(`Persona not found: ${agentConfig.persona}`)
+  }
+
+  // 2. Skills の解決
+  const resolvedSkills: Skill[] = []
+  for (const skillName of agentConfig.skills) {
+    const skill = skills.get(skillName)
+    if (skill === undefined) {
+      return err(`Skill not found: ${skillName}`)
+    }
+    resolvedSkills.push(skill)
+  }
+
+  // 3. Provider の解決
+  const providerConfig = wnConfig.providers[agentConfig.provider]
+  if (providerConfig === undefined) {
+    return err(`Provider not found: ${agentConfig.provider}`)
+  }
+
+  // 4. systemMessage の組み立て
+  const systemMessage =
+    resolvedSkills.length === 0
+      ? persona.content
+      : [persona.content, ...resolvedSkills.map((s) => s.body)].join('\n\n')
+
+  // 5. mcpServers
+  const mcpServers = wnConfig.mcp?.servers ?? []
+
+  // 6. 成功
+  return ok({
+    id,
+    task: agentConfig.task,
+    systemMessage,
+    providerName: agentConfig.provider,
+    providerConfig,
+    model: agentConfig.model,
+    mcpServers,
+  })
+}
+
+/**
+ * unknown な値が WorkerMessage 型かどうかを判定する型ガード。
+ */
+export function isWorkerMessage(value: unknown): value is WorkerMessage {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+  const { type } = obj
+
+  switch (type) {
+    case 'result':
+      return typeof obj['data'] === 'string'
+
+    case 'error':
+      return typeof obj['error'] === 'string'
+
+    case 'log':
+      return (
+        (obj['level'] === 'info' || obj['level'] === 'warn' || obj['level'] === 'error') &&
+        typeof obj['message'] === 'string'
+      )
+
+    default:
+      return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 内部ミュータブルハンドル（Worker イベントで status/result を更新）
+// ---------------------------------------------------------------------------
+
+interface MutableHandle {
+  readonly id: string
+  status: SubAgentStatus
+  result?: unknown
+  worker?: Worker
+}
+
+function toReadonly(h: MutableHandle): SubAgentHandle {
+  return { id: h.id, status: h.status, result: h.result }
+}
+
+// ---------------------------------------------------------------------------
+// WorkerSubAgentRunner
+// ---------------------------------------------------------------------------
+
+const DEFAULT_WORKER_URL = new URL('./sub-agent-worker.js', import.meta.url)
+
+/**
+ * Worker Threads で AgentLoop を並列実行するサブエージェントランナー。
+ */
+export class WorkerSubAgentRunner implements SubAgentRunner {
+  private readonly handles = new Map<string, MutableHandle>()
+  private readonly options: SubAgentRunnerOptions
+
+  constructor(options: SubAgentRunnerOptions) {
+    this.options = options
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await -- インターフェース準拠のため async を維持
+  async spawn(config: AgentConfig): Promise<SubAgentHandle> {
+    const id = randomUUID()
+
+    // 名前解決
+    const resolved = resolveWorkerData(
+      id,
+      config,
+      this.options.config,
+      this.options.personas,
+      this.options.skills,
+    )
+
+    if (!resolved.ok) {
+      const handle: MutableHandle = { id, status: 'failed', result: resolved.error }
+      this.handles.set(id, handle)
+      return toReadonly(handle)
+    }
+
+    // Worker 起動
+    const workerUrl = this.options.workerUrl ?? DEFAULT_WORKER_URL
+    const worker = new Worker(workerUrl, { workerData: resolved.data })
+
+    const handle: MutableHandle = { id, status: 'running', worker }
+    this.handles.set(id, handle)
+
+    // message イベント
+    worker.on('message', (msg: unknown) => {
+      if (!isWorkerMessage(msg)) return
+
+      switch (msg.type) {
+        case 'result':
+          handle.status = 'completed'
+          handle.result = msg.data
+          break
+        case 'error':
+          handle.status = 'failed'
+          handle.result = msg.error
+          break
+        case 'log':
+          // 将来の拡張ポイント（現在は無視）
+          break
+      }
+    })
+
+    // error イベント
+    worker.on('error', () => {
+      handle.status = 'failed'
+    })
+
+    // exit イベント（異常終了のみ）
+    worker.on('exit', (code: number) => {
+      if (code !== 0 && handle.status === 'running') {
+        handle.status = 'failed'
+      }
+    })
+
+    return toReadonly(handle)
+  }
+
+  list(): SubAgentHandle[] {
+    return [...this.handles.values()].map(toReadonly)
+  }
+
+  async stop(id: string): Promise<void> {
+    const handle = this.handles.get(id)
+    if (!handle?.worker) return
+
+    await handle.worker.terminate()
+    handle.status = 'failed'
+  }
+}

--- a/src/agent/sub-agent-worker.ts
+++ b/src/agent/sub-agent-worker.ts
@@ -1,0 +1,110 @@
+/**
+ * サブエージェント Worker
+ *
+ * Worker Thread として実行され、サブエージェントの LLM 対話ループを駆動する。
+ * - createProviderByName: プロバイダー名から LLMProvider を生成
+ * - runSubAgent: Worker 内でのエージェント実行エントリポイント
+ */
+import type { Result } from '../result.js'
+import { err } from '../result.js'
+import type { LLMProvider } from '../providers/types.js'
+import type { ProviderConfig } from '../loader/types.js'
+import type { SubAgentWorkerData, MessageSender, WorkerMessage } from './types.js'
+import { createClaudeProvider } from '../providers/claude.js'
+import { createOpenAIProvider } from '../providers/openai.js'
+import { createOllamaProvider } from '../providers/ollama.js'
+import { createGeminiProvider } from '../providers/gemini.js'
+import { ToolRegistry } from '../tools/types.js'
+import { createReadTool } from '../tools/read.js'
+import { createWriteTool } from '../tools/write.js'
+import { createGrepTool } from '../tools/grep.js'
+import { createShellTool } from '../tools/shell.js'
+import { AgentLoop, createNoopHandler } from './agent-loop.js'
+import { isMainThread, parentPort, workerData } from 'node:worker_threads'
+
+/**
+ * プロバイダー名から LLMProvider を生成する
+ *
+ * @param name - プロバイダー名 ('claude' | 'openai' | 'ollama' | 'gemini')
+ * @param config - プロバイダー設定
+ * @param model - 使用するモデル名
+ * @returns Result<LLMProvider> - 成功時はプロバイダー、失敗時はエラーメッセージ
+ */
+export function createProviderByName(
+  name: string,
+  config: ProviderConfig,
+  model: string,
+): Result<LLMProvider> {
+  switch (name) {
+    case 'claude':
+      return createClaudeProvider(config, model)
+    case 'openai':
+      return createOpenAIProvider(config, model)
+    case 'ollama':
+      return createOllamaProvider(config, model)
+    case 'gemini':
+      return createGeminiProvider(config, model)
+    default:
+      return err(`Unknown provider: ${name}`)
+  }
+}
+
+/**
+ * サブエージェントを実行する
+ *
+ * Worker Thread 内で呼び出され、LLM プロバイダーの生成、ツール登録、
+ * AgentLoop の step() 実行を行い、結果を MessageSender 経由で返す。
+ *
+ * @param data - Worker に渡されたサブエージェント設定データ
+ * @param sender - メッセージ送信インターフェース
+ */
+export async function runSubAgent(data: SubAgentWorkerData, sender: MessageSender): Promise<void> {
+  try {
+    // 1. プロバイダー生成
+    const providerResult = createProviderByName(data.providerName, data.providerConfig, data.model)
+
+    if (!providerResult.ok) {
+      sender.postMessage({ type: 'error', error: providerResult.error })
+      return
+    }
+
+    // 2. ToolRegistry を作成し、ビルトインツールを登録
+    const tools = new ToolRegistry()
+    tools.register(createReadTool())
+    tools.register(createWriteTool())
+    tools.register(createGrepTool())
+    tools.register(createShellTool())
+
+    // 3. AgentLoop を作成
+    const loop = new AgentLoop({
+      provider: providerResult.data,
+      tools,
+      handler: createNoopHandler(),
+      systemMessage: data.systemMessage,
+    })
+
+    // 4. step() を実行
+    const stepResult = await loop.step(data.task)
+
+    if (stepResult.ok) {
+      sender.postMessage({ type: 'result', data: stepResult.data })
+    } else {
+      sender.postMessage({ type: 'error', error: stepResult.error })
+    }
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e)
+    sender.postMessage({ type: 'error', error: message })
+  }
+}
+
+// Worker エントリポイント: Worker Thread として実行された場合のみ自動実行
+if (!isMainThread && parentPort !== null) {
+  const port = parentPort
+  const data = workerData as SubAgentWorkerData
+  const sender: MessageSender = {
+    postMessage(msg: WorkerMessage): void {
+      port.postMessage(msg)
+    },
+  }
+  void runSubAgent(data, sender)
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,5 +1,6 @@
 import type { LLMProvider, TokenUsage } from '../providers/types.js'
 import type { ToolRegistry, ToolResult } from '../tools/types.js'
+import type { McpServerConfig, Persona, ProviderConfig, Skill, WnConfig } from '../loader/types.js'
 
 /**
  * サブエージェントのステータス
@@ -36,6 +37,38 @@ export interface SubAgentRunner {
 
   /** サブエージェントを停止する */
   stop(id: string): Promise<void>
+}
+
+// --- SubAgent Worker 関連 ---
+
+/** Worker に渡すシリアライズ可能なデータ */
+export interface SubAgentWorkerData {
+  readonly id: string
+  readonly task: string
+  readonly systemMessage: string
+  readonly providerName: string
+  readonly providerConfig: ProviderConfig
+  readonly model: string
+  readonly mcpServers: readonly McpServerConfig[]
+}
+
+/** Worker → Main メッセージ */
+export type WorkerMessage =
+  | { readonly type: 'result'; readonly data: string }
+  | { readonly type: 'error'; readonly error: string }
+  | { readonly type: 'log'; readonly level: 'info' | 'warn' | 'error'; readonly message: string }
+
+/** WorkerSubAgentRunner のコンストラクタオプション */
+export interface SubAgentRunnerOptions {
+  readonly config: WnConfig
+  readonly personas: ReadonlyMap<string, Persona>
+  readonly skills: ReadonlyMap<string, Skill>
+  readonly workerUrl?: string | URL
+}
+
+/** Worker 内メッセージ送信インターフェース（テスト用に分離） */
+export interface MessageSender {
+  postMessage(msg: WorkerMessage): void
 }
 
 // --- AgentLoop 関連 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,10 +35,23 @@ export type { ShellConfig } from './tools/shell.js'
 
 // Agent types
 export type { SubAgentStatus, SubAgentHandle, AgentConfig, SubAgentRunner } from './agent/types.js'
+export type {
+  SubAgentWorkerData,
+  WorkerMessage,
+  SubAgentRunnerOptions,
+  MessageSender,
+} from './agent/types.js'
 export type { AgentLoopState, AgentLoopHandler, AgentLoopOptions } from './agent/types.js'
 
 // AgentLoop
 export { AgentLoop, createNoopHandler } from './agent/agent-loop.js'
+
+// SubAgentRunner
+export {
+  resolveWorkerData,
+  isWorkerMessage,
+  WorkerSubAgentRunner,
+} from './agent/sub-agent-runner.js'
 
 // Loader types
 export type {

--- a/tests/agent/sub-agent-runner.test.ts
+++ b/tests/agent/sub-agent-runner.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect, vi, type Mock } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { ok, err } from '../../src/result.js'
+import type {
+  AgentConfig,
+  SubAgentWorkerData,
+  SubAgentRunnerOptions,
+} from '../../src/agent/types.js'
+import type { Persona, Skill, WnConfig } from '../../src/loader/types.js'
+import {
+  resolveWorkerData,
+  isWorkerMessage,
+  WorkerSubAgentRunner,
+} from '../../src/agent/sub-agent-runner.js'
+
+// ---------------------------------------------------------------------------
+// ヘルパー: テスト用のデフォルトデータを生成
+// ---------------------------------------------------------------------------
+
+function createDefaultPersonas(): ReadonlyMap<string, Persona> {
+  return new Map<string, Persona>([
+    ['pentester', { name: 'pentester', content: 'You are a penetration tester.' }],
+    ['analyst', { name: 'analyst', content: 'You are a security analyst.' }],
+  ])
+}
+
+function createDefaultSkills(): ReadonlyMap<string, Skill> {
+  return new Map<string, Skill>([
+    [
+      'recon',
+      {
+        name: 'recon',
+        description: 'Reconnaissance skill',
+        tools: ['nmap', 'whois'],
+        body: 'Perform reconnaissance on the target.',
+      },
+    ],
+    [
+      'exploit',
+      {
+        name: 'exploit',
+        description: 'Exploitation skill',
+        tools: ['metasploit'],
+        body: 'Attempt to exploit discovered vulnerabilities.',
+      },
+    ],
+  ])
+}
+
+function createDefaultWnConfig(overrides?: Partial<WnConfig>): WnConfig {
+  return {
+    defaultProvider: 'claude',
+    defaultModel: 'claude-sonnet-4-20250514',
+    defaultPersona: 'pentester',
+    providers: {
+      claude: { apiKey: 'sk-test-key', baseUrl: 'https://api.anthropic.com' },
+      openai: { apiKey: 'sk-openai-key' },
+    },
+    mcp: {
+      servers: [
+        {
+          name: 'filesystem',
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-filesystem'],
+        },
+      ],
+    },
+    ...overrides,
+  }
+}
+
+function createDefaultAgentConfig(overrides?: Partial<AgentConfig>): AgentConfig {
+  return {
+    persona: 'pentester',
+    skills: ['recon', 'exploit'],
+    provider: 'claude',
+    model: 'claude-sonnet-4-20250514',
+    task: 'Scan the target network',
+    ...overrides,
+  }
+}
+
+// ===========================================================================
+// テスト本体
+// ===========================================================================
+
+describe('resolveWorkerData', () => {
+  it('正常系: persona + skills + provider が全て解決できる', () => {
+    const personas = createDefaultPersonas()
+    const skills = createDefaultSkills()
+    const wnConfig = createDefaultWnConfig()
+    const agentConfig = createDefaultAgentConfig()
+
+    const result = resolveWorkerData('agent-1', agentConfig, wnConfig, personas, skills)
+
+    expect(result).toStrictEqual(
+      ok<SubAgentWorkerData>({
+        id: 'agent-1',
+        task: 'Scan the target network',
+        systemMessage:
+          'You are a penetration tester.\n\n' +
+          'Perform reconnaissance on the target.\n\n' +
+          'Attempt to exploit discovered vulnerabilities.',
+        providerName: 'claude',
+        providerConfig: { apiKey: 'sk-test-key', baseUrl: 'https://api.anthropic.com' },
+        model: 'claude-sonnet-4-20250514',
+        mcpServers: [
+          {
+            name: 'filesystem',
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-filesystem'],
+          },
+        ],
+      }),
+    )
+  })
+
+  it('persona が見つからない場合エラーを返す', () => {
+    const personas = createDefaultPersonas()
+    const skills = createDefaultSkills()
+    const wnConfig = createDefaultWnConfig()
+    const agentConfig = createDefaultAgentConfig({ persona: 'nonexistent' })
+
+    const result = resolveWorkerData('agent-2', agentConfig, wnConfig, personas, skills)
+
+    expect(result).toStrictEqual(err('Persona not found: nonexistent'))
+  })
+
+  it('skill が見つからない場合エラーを返す', () => {
+    const personas = createDefaultPersonas()
+    const skills = createDefaultSkills()
+    const wnConfig = createDefaultWnConfig()
+    const agentConfig = createDefaultAgentConfig({ skills: ['recon', 'unknown-skill'] })
+
+    const result = resolveWorkerData('agent-3', agentConfig, wnConfig, personas, skills)
+
+    expect(result).toStrictEqual(err('Skill not found: unknown-skill'))
+  })
+
+  it('provider が見つからない場合エラーを返す', () => {
+    const personas = createDefaultPersonas()
+    const skills = createDefaultSkills()
+    const wnConfig = createDefaultWnConfig()
+    const agentConfig = createDefaultAgentConfig({ provider: 'gemini' })
+
+    const result = resolveWorkerData('agent-4', agentConfig, wnConfig, personas, skills)
+
+    expect(result).toStrictEqual(err('Provider not found: gemini'))
+  })
+
+  it('skills が空配列の場合は persona.content のみが systemMessage になる', () => {
+    const personas = createDefaultPersonas()
+    const skills = createDefaultSkills()
+    const wnConfig = createDefaultWnConfig()
+    const agentConfig = createDefaultAgentConfig({ skills: [] })
+
+    const result = resolveWorkerData('agent-5', agentConfig, wnConfig, personas, skills)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.systemMessage).toBe('You are a penetration tester.')
+    }
+  })
+
+  it('mcp 設定がない場合は空配列になる', () => {
+    const personas = createDefaultPersonas()
+    const skills = createDefaultSkills()
+    // mcp プロパティを省略した WnConfig
+    const wnConfig: WnConfig = {
+      defaultProvider: 'claude',
+      defaultModel: 'claude-sonnet-4-20250514',
+      defaultPersona: 'pentester',
+      providers: {
+        claude: { apiKey: 'sk-test-key' },
+      },
+    }
+    const agentConfig = createDefaultAgentConfig()
+
+    const result = resolveWorkerData('agent-6', agentConfig, wnConfig, personas, skills)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.mcpServers).toStrictEqual([])
+    }
+  })
+})
+
+describe('isWorkerMessage', () => {
+  it('有効な WorkerMessage を正しく判定する', () => {
+    // --- 有効なメッセージ ---
+
+    // result メッセージ
+    expect(isWorkerMessage({ type: 'result', data: 'some output' })).toBe(true)
+
+    // error メッセージ
+    expect(isWorkerMessage({ type: 'error', error: 'something went wrong' })).toBe(true)
+
+    // log メッセージ (各 level)
+    expect(isWorkerMessage({ type: 'log', level: 'info', message: 'info msg' })).toBe(true)
+    expect(isWorkerMessage({ type: 'log', level: 'warn', message: 'warn msg' })).toBe(true)
+    expect(isWorkerMessage({ type: 'log', level: 'error', message: 'error msg' })).toBe(true)
+
+    // --- 無効な値 ---
+
+    // null / undefined / プリミティブ
+    expect(isWorkerMessage(null)).toBe(false)
+    expect(isWorkerMessage(undefined)).toBe(false)
+    expect(isWorkerMessage(42)).toBe(false)
+    expect(isWorkerMessage('string')).toBe(false)
+
+    // type プロパティが不正
+    expect(isWorkerMessage({ type: 'unknown' })).toBe(false)
+    expect(isWorkerMessage({})).toBe(false)
+
+    // result だが data が string でない
+    expect(isWorkerMessage({ type: 'result', data: 123 })).toBe(false)
+    expect(isWorkerMessage({ type: 'result' })).toBe(false)
+
+    // error だが error が string でない
+    expect(isWorkerMessage({ type: 'error', error: 123 })).toBe(false)
+    expect(isWorkerMessage({ type: 'error' })).toBe(false)
+
+    // log だが level が不正
+    expect(isWorkerMessage({ type: 'log', level: 'debug', message: 'msg' })).toBe(false)
+    expect(isWorkerMessage({ type: 'log', level: 'info' })).toBe(false)
+    expect(isWorkerMessage({ type: 'log', message: 'msg' })).toBe(false)
+    expect(isWorkerMessage({ type: 'log', level: 'info', message: 123 })).toBe(false)
+  })
+})
+
+// ===========================================================================
+// WorkerSubAgentRunner テスト
+// ===========================================================================
+
+// Worker モック
+vi.mock('node:worker_threads', () => {
+  return {
+    Worker: vi.fn(),
+    isMainThread: true,
+    parentPort: null,
+    workerData: null,
+  }
+})
+
+const { Worker } = await import('node:worker_threads')
+
+class MockWorker extends EventEmitter {
+  terminate = vi.fn<() => Promise<number>>().mockResolvedValue(0)
+}
+
+function createMockWorker(): MockWorker {
+  const mw = new MockWorker()
+  ;(Worker as unknown as Mock).mockImplementation(function () {
+    return mw
+  })
+  return mw
+}
+
+function createRunnerOptions(overrides?: Partial<SubAgentRunnerOptions>): SubAgentRunnerOptions {
+  return {
+    config: createDefaultWnConfig(),
+    personas: createDefaultPersonas(),
+    skills: createDefaultSkills(),
+    workerUrl: new URL('file:///fake-worker.js'),
+    ...overrides,
+  }
+}
+
+describe('WorkerSubAgentRunner', () => {
+  describe('spawn', () => {
+    it('名前解決成功時に Worker を起動し running ハンドルを返す', async () => {
+      createMockWorker()
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+      const agentConfig = createDefaultAgentConfig()
+
+      const handle = await runner.spawn(agentConfig)
+
+      expect(handle.id).toEqual(expect.any(String))
+      expect(handle.status).toBe('running')
+      // Worker コンストラクタが呼ばれたことを確認
+      expect(Worker).toHaveBeenCalledOnce()
+    })
+
+    it('persona 解決失敗時に即座に failed ハンドルを返す（Worker は起動しない）', async () => {
+      ;(Worker as unknown as Mock).mockClear()
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+      const agentConfig = createDefaultAgentConfig({ persona: 'nonexistent' })
+
+      const handle = await runner.spawn(agentConfig)
+
+      expect(handle.status).toBe('failed')
+      expect(handle.result).toEqual(expect.stringContaining('Persona not found'))
+      // Worker は起動しない
+      expect(Worker).not.toHaveBeenCalled()
+    })
+
+    it('Worker の result メッセージで status が completed になる', async () => {
+      const mw = createMockWorker()
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+      const agentConfig = createDefaultAgentConfig()
+
+      const handle = await runner.spawn(agentConfig)
+      expect(handle.status).toBe('running')
+
+      // Worker から result メッセージを送信
+      mw.emit('message', { type: 'result', data: 'scan completed' })
+
+      // list() 経由で最新の handle を取得
+      const handles = runner.list()
+      const updated = handles.find((h) => h.id === handle.id)
+      expect(updated).toBeDefined()
+      expect(updated?.status).toBe('completed')
+      expect(updated?.result).toBe('scan completed')
+    })
+
+    it('Worker の error メッセージで status が failed になる', async () => {
+      const mw = createMockWorker()
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+      const agentConfig = createDefaultAgentConfig()
+
+      const handle = await runner.spawn(agentConfig)
+
+      // Worker から error メッセージを送信
+      mw.emit('message', { type: 'error', error: 'provider timeout' })
+
+      const handles = runner.list()
+      const updated = handles.find((h) => h.id === handle.id)
+      expect(updated).toBeDefined()
+      expect(updated?.status).toBe('failed')
+      expect(updated?.result).toBe('provider timeout')
+    })
+
+    it('Worker の error イベントで status が failed になる', async () => {
+      const mw = createMockWorker()
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+      const agentConfig = createDefaultAgentConfig()
+
+      const handle = await runner.spawn(agentConfig)
+
+      // Worker の error イベントを発火
+      mw.emit('error', new Error('worker crashed'))
+
+      const handles = runner.list()
+      const updated = handles.find((h) => h.id === handle.id)
+      expect(updated).toBeDefined()
+      expect(updated?.status).toBe('failed')
+    })
+
+    it('Worker の異常終了（exit code !== 0）で status が failed になる', async () => {
+      const mw = createMockWorker()
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+      const agentConfig = createDefaultAgentConfig()
+
+      const handle = await runner.spawn(agentConfig)
+
+      // Worker が異常終了
+      mw.emit('exit', 1)
+
+      const handles = runner.list()
+      const updated = handles.find((h) => h.id === handle.id)
+      expect(updated).toBeDefined()
+      expect(updated?.status).toBe('failed')
+    })
+
+    it('Worker の正常終了（exit code === 0）で status は変わらない', async () => {
+      const mw = createMockWorker()
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+      const agentConfig = createDefaultAgentConfig()
+
+      const handle = await runner.spawn(agentConfig)
+      expect(handle.status).toBe('running')
+
+      // Worker が正常終了
+      mw.emit('exit', 0)
+
+      const handles = runner.list()
+      const updated = handles.find((h) => h.id === handle.id)
+      expect(updated).toBeDefined()
+      // running のまま（result メッセージで completed に遷移済みのはず）
+      // 正常終了だけでは status を変えない
+      expect(updated?.status).toBe('running')
+    })
+  })
+
+  describe('list', () => {
+    it('空の状態では空配列を返す', () => {
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+
+      expect(runner.list()).toStrictEqual([])
+    })
+
+    it('spawn した全ハンドルを返す（完了分含む）', async () => {
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+
+      // 1つ目: running のまま
+      createMockWorker()
+      const handle1 = await runner.spawn(createDefaultAgentConfig({ task: 'task-1' }))
+
+      // 2つ目: completed にする
+      const mw2 = createMockWorker()
+      const handle2 = await runner.spawn(createDefaultAgentConfig({ task: 'task-2' }))
+      mw2.emit('message', { type: 'result', data: 'done' })
+
+      const handles = runner.list()
+      expect(handles).toHaveLength(2)
+
+      const ids = handles.map((h) => h.id)
+      expect(ids).toContain(handle1.id)
+      expect(ids).toContain(handle2.id)
+
+      // completed 分も含まれることを確認
+      const completedHandle = handles.find((h) => h.id === handle2.id)
+      expect(completedHandle?.status).toBe('completed')
+    })
+  })
+
+  describe('stop', () => {
+    it('指定 ID の Worker を terminate する', async () => {
+      const mw = createMockWorker()
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+      const agentConfig = createDefaultAgentConfig()
+
+      const handle = await runner.spawn(agentConfig)
+
+      await runner.stop(handle.id)
+
+      expect(mw.terminate).toHaveBeenCalledOnce()
+
+      // status が failed になる
+      const handles = runner.list()
+      const updated = handles.find((h) => h.id === handle.id)
+      expect(updated).toBeDefined()
+      expect(updated?.status).toBe('failed')
+    })
+
+    it('存在しない ID で呼んでもエラーにならない', async () => {
+      const runner = new WorkerSubAgentRunner(createRunnerOptions())
+
+      // 例外が投げられないことを確認
+      await expect(runner.stop('nonexistent-id')).resolves.toBeUndefined()
+    })
+  })
+})

--- a/tests/agent/sub-agent-worker.test.ts
+++ b/tests/agent/sub-agent-worker.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import { ok, err } from '../../src/result.js'
+import type { LLMProvider } from '../../src/providers/types.js'
+import type { ProviderConfig } from '../../src/loader/types.js'
+import type { SubAgentWorkerData, WorkerMessage } from '../../src/agent/types.js'
+
+// ---------------------------------------------------------------------------
+// モック: プロバイダーファクトリ
+// ---------------------------------------------------------------------------
+vi.mock('../../src/providers/claude.js', () => ({
+  createClaudeProvider: vi.fn(),
+}))
+vi.mock('../../src/providers/openai.js', () => ({
+  createOpenAIProvider: vi.fn(),
+}))
+vi.mock('../../src/providers/ollama.js', () => ({
+  createOllamaProvider: vi.fn(),
+}))
+vi.mock('../../src/providers/gemini.js', () => ({
+  createGeminiProvider: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// モック: AgentLoop / createNoopHandler
+// ---------------------------------------------------------------------------
+const mockStep = vi.fn()
+
+vi.mock('../../src/agent/agent-loop.js', () => ({
+  AgentLoop: vi.fn().mockImplementation(function () {
+    return { step: mockStep }
+  }),
+  createNoopHandler: vi.fn(() => ({
+    onResponse: vi.fn(),
+    onToolStart: vi.fn(),
+    onToolEnd: vi.fn(),
+    onStateChange: vi.fn(),
+    onError: vi.fn(),
+    onUsage: vi.fn(),
+  })),
+}))
+
+// ---------------------------------------------------------------------------
+// モック: ToolRegistry
+// ---------------------------------------------------------------------------
+vi.mock('../../src/tools/types.js', () => ({
+  ToolRegistry: vi.fn().mockImplementation(function () {
+    return {
+      register: vi.fn(() => ({ ok: true, data: undefined })),
+      list: vi.fn(() => []),
+      get: vi.fn(),
+    }
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// モック: ビルトインツール
+// ---------------------------------------------------------------------------
+vi.mock('../../src/tools/read.js', () => ({
+  createReadTool: vi.fn(() => ({
+    name: 'read',
+    description: 'Read a file',
+    parameters: {},
+    execute: vi.fn(),
+  })),
+}))
+vi.mock('../../src/tools/write.js', () => ({
+  createWriteTool: vi.fn(() => ({
+    name: 'write',
+    description: 'Write a file',
+    parameters: {},
+    execute: vi.fn(),
+  })),
+}))
+vi.mock('../../src/tools/grep.js', () => ({
+  createGrepTool: vi.fn(() => ({
+    name: 'grep',
+    description: 'Search files',
+    parameters: {},
+    execute: vi.fn(),
+  })),
+}))
+vi.mock('../../src/tools/shell.js', () => ({
+  createShellTool: vi.fn(() => ({
+    name: 'shell',
+    description: 'Run shell command',
+    parameters: {},
+    execute: vi.fn(),
+  })),
+}))
+
+// ---------------------------------------------------------------------------
+// テスト対象のインポート（vi.mock の後に配置）
+// ---------------------------------------------------------------------------
+import { createProviderByName, runSubAgent } from '../../src/agent/sub-agent-worker.js'
+import { createClaudeProvider } from '../../src/providers/claude.js'
+import { createOpenAIProvider } from '../../src/providers/openai.js'
+import { createOllamaProvider } from '../../src/providers/ollama.js'
+import { createGeminiProvider } from '../../src/providers/gemini.js'
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+/** ダミーの LLMProvider */
+function createDummyProvider(): LLMProvider {
+  return {
+    complete: vi.fn(),
+  }
+}
+
+/** テスト用 SubAgentWorkerData を生成する */
+function createWorkerData(overrides?: Partial<SubAgentWorkerData>): SubAgentWorkerData {
+  return {
+    id: 'sub-1',
+    task: 'Do something useful',
+    systemMessage: 'You are an assistant.',
+    providerName: 'claude',
+    providerConfig: { apiKey: 'test-key' },
+    model: 'claude-sonnet-4-20250514',
+    mcpServers: [],
+    ...overrides,
+  }
+}
+
+/** スパイ付き MessageSender を生成する */
+function createMockSender(): {
+  postMessage: Mock<(msg: WorkerMessage) => void>
+} {
+  return {
+    postMessage: vi.fn<(msg: WorkerMessage) => void>(),
+  }
+}
+
+// ===========================================================================
+// テスト本体
+// ===========================================================================
+
+describe('createProviderByName', () => {
+  const config: ProviderConfig = { apiKey: 'test-key' }
+  const model = 'test-model'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('claude プロバイダーを生成できる', () => {
+    const dummyProvider = createDummyProvider()
+    ;(createClaudeProvider as Mock).mockReturnValue(ok(dummyProvider))
+
+    const result = createProviderByName('claude', config, model)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data).toBe(dummyProvider)
+    }
+    expect(createClaudeProvider).toHaveBeenCalledWith(config, model)
+    expect(createClaudeProvider).toHaveBeenCalledTimes(1)
+  })
+
+  it('openai プロバイダーを生成できる', () => {
+    const dummyProvider = createDummyProvider()
+    ;(createOpenAIProvider as Mock).mockReturnValue(ok(dummyProvider))
+
+    const result = createProviderByName('openai', config, model)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data).toBe(dummyProvider)
+    }
+    expect(createOpenAIProvider).toHaveBeenCalledWith(config, model)
+    expect(createOpenAIProvider).toHaveBeenCalledTimes(1)
+  })
+
+  it('ollama プロバイダーを生成できる', () => {
+    const dummyProvider = createDummyProvider()
+    ;(createOllamaProvider as Mock).mockReturnValue(ok(dummyProvider))
+
+    const result = createProviderByName('ollama', config, model)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data).toBe(dummyProvider)
+    }
+    expect(createOllamaProvider).toHaveBeenCalledWith(config, model)
+    expect(createOllamaProvider).toHaveBeenCalledTimes(1)
+  })
+
+  it('未知のプロバイダー名でエラーを返す', () => {
+    const result = createProviderByName('unknown-provider', config, model)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBe('Unknown provider: unknown-provider')
+    }
+    // どのファクトリも呼ばれない
+    expect(createClaudeProvider).not.toHaveBeenCalled()
+    expect(createOpenAIProvider).not.toHaveBeenCalled()
+    expect(createOllamaProvider).not.toHaveBeenCalled()
+    expect(createGeminiProvider).not.toHaveBeenCalled()
+  })
+})
+
+describe('runSubAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStep.mockReset()
+  })
+
+  it('正常系: AgentLoop.step が成功し result メッセージを送信する', async () => {
+    // プロバイダー生成成功
+    const dummyProvider = createDummyProvider()
+    ;(createClaudeProvider as Mock).mockReturnValue(ok(dummyProvider))
+
+    // AgentLoop.step が成功結果を返す
+    mockStep.mockResolvedValue(ok('Task completed successfully'))
+
+    const sender = createMockSender()
+    const data = createWorkerData()
+
+    await runSubAgent(data, sender)
+
+    // result メッセージが送信される
+    expect(sender.postMessage).toHaveBeenCalledWith({
+      type: 'result',
+      data: 'Task completed successfully',
+    })
+    // error メッセージは送信されない
+    const errorCalls = sender.postMessage.mock.calls.filter((call) => call[0].type === 'error')
+    expect(errorCalls).toHaveLength(0)
+  })
+
+  it('プロバイダー生成失敗時に error メッセージを送信する', async () => {
+    // プロバイダー生成失敗
+    ;(createClaudeProvider as Mock).mockReturnValue(err('API key is required'))
+
+    const sender = createMockSender()
+    const data = createWorkerData()
+
+    await runSubAgent(data, sender)
+
+    // error メッセージが送信される
+    expect(sender.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+      }),
+    )
+    // result メッセージは送信されない
+    const resultCalls = sender.postMessage.mock.calls.filter((call) => call[0].type === 'result')
+    expect(resultCalls).toHaveLength(0)
+    // AgentLoop.step は呼ばれない
+    expect(mockStep).not.toHaveBeenCalled()
+  })
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -21,6 +21,9 @@ import {
   createOllamaProvider,
   createGeminiProvider,
   createMcpManager,
+  resolveWorkerData,
+  isWorkerMessage,
+  WorkerSubAgentRunner,
 } from '../src/index.js'
 import type { ShellConfig } from '../src/index.js'
 import type {
@@ -42,6 +45,10 @@ import type {
   AgentLoopState,
   AgentLoopHandler,
   AgentLoopOptions,
+  SubAgentWorkerData,
+  WorkerMessage,
+  SubAgentRunnerOptions,
+  MessageSender,
   WnConfig,
   ProviderConfig,
   McpConfig,
@@ -171,6 +178,18 @@ describe('wn-core', () => {
     expect(typeof createOpenAIProvider).toBe('function')
     expect(typeof createOllamaProvider).toBe('function')
     expect(typeof createGeminiProvider).toBe('function')
+  })
+
+  it('SubAgentRunner 関連がエクスポートされている', () => {
+    expect(typeof resolveWorkerData).toBe('function')
+    expect(typeof isWorkerMessage).toBe('function')
+    expect(typeof WorkerSubAgentRunner).toBe('function')
+
+    // 型がインポート可能であることを検証
+    expect(undefined as SubAgentWorkerData | undefined).toBeUndefined()
+    expect(undefined as WorkerMessage | undefined).toBeUndefined()
+    expect(undefined as SubAgentRunnerOptions | undefined).toBeUndefined()
+    expect(undefined as MessageSender | undefined).toBeUndefined()
   })
 
   it('MCP Client がエクスポートされている', () => {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup"
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/agent/sub-agent-worker.ts"],
   format: ["esm"],
   dts: true,
   target: "node20",


### PR DESCRIPTION
## Summary

- Worker Threads で AgentLoop を並列実行する `SubAgentRunner` を実装
- ペンテスト用途の CPU ヘビーなタスク（nmap XML パース、Nuclei JSON 処理等）を真の並列で処理可能にする
- `docs/architecture.md` Section 5.5 の設計に準拠

### 新規ファイル
- `src/agent/sub-agent-runner.ts` — `resolveWorkerData`, `isWorkerMessage`, `WorkerSubAgentRunner`
- `src/agent/sub-agent-worker.ts` — `createProviderByName`, `runSubAgent`, Worker エントリポイント
- `tests/agent/sub-agent-runner.test.ts` — 18 テスト
- `tests/agent/sub-agent-worker.test.ts` — 6 テスト

### 変更ファイル
- `src/agent/types.ts` — `SubAgentWorkerData`, `WorkerMessage`, `SubAgentRunnerOptions`, `MessageSender` 型追加
- `src/index.ts` — エクスポート追加
- `tsup.config.ts` — Worker エントリポイント追加
- `tests/index.test.ts` — エクスポート検証追加

## Test plan

- [x] `npm run typecheck` — 型チェッククリーン
- [x] `npm run lint` — lint クリーン
- [x] `npm run format:check` — フォーマットクリーン
- [x] `npx vitest run` — 264 テスト全パス (24 新規)
- [x] `npm run build` — `dist/agent/sub-agent-worker.js` 生成確認
- [x] Semgrep スキャン — findings 0

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)