### PR TITLE
feat: CLI エントリーポイント実装 (wn-core serve)

### DIFF
--- a/docs/plan-cli-entrypoint.md
+++ b/docs/plan-cli-entrypoint.md
@@ -1,0 +1,108 @@
+# 計画: wn-core CLI エントリーポイント実装
+
+## コンテキスト
+
+wn-core の全コンポーネント（LLMProvider, AgentLoop, Tools, MCP, RPC Server）は実装済みだが、起動スクリプト（CLI エントリーポイント）がない。TUI（wn-tui）が `child_process.spawn('wn-core', ['serve'])` で Core を起動し、stdin/stdout の JSON-RPC で通信する構成を実現するため、CLI を実装する。
+
+**最終的な公開イメージ:**
+- `wn-core`: npm パッケージ（ライブラリ + CLI）
+- `wn-tui`: `wn-core` を依存に持ち、`weness` コマンドとして公開
+
+## 設計
+
+### CLI コマンド体系
+
+最小構成で `serve` サブコマンドのみ実装する。
+
+```
+wn-core serve [options]     # RPC サーバーとして起動（TUI から spawn される）
+```
+
+**オプション:**
+- `--provider <name>` — LLM プロバイダー指定（default: config.json の defaultProvider）
+- `--model <name>` — モデル指定（default: config.json の defaultModel）
+- `--persona <name>` — ペルソナ指定（default: config.json の defaultPersona）
+
+### CLI 引数パーサー
+
+**`node:util` の `parseArgs` を使用**（外部依存ゼロ）。サブコマンドは positional で取得。
+
+### ブートストラップフロー（`docs/architecture.md` Section 7 の実装）
+
+```
+1. CLI パース (parseArgs)
+2. loadConfig(globalDir, localDir, cliOverrides)
+3. LLMProvider 生成 (createProvider ルーター)
+4. loadPersonas / loadSkills / loadAgents
+5. ToolRegistry 構築 (built-in + MCP)
+6. RPC Server + AgentLoop 接続
+7. rpcServer.start() — stdin/stdout でリッスン開始
+8. シャットダウン処理 (MCP 切断, プロセス終了)
+```
+
+### プロバイダールーター
+
+プロバイダー名 → ファクトリ関数のマッピング。
+
+```typescript
+function createProvider(name: string, config: ProviderConfig, model: string): Result<LLMProvider>
+```
+
+### ログ出力
+
+RPC モードでは stdout は JSON-RPC 専用。ログは **stderr** に出力する。
+
+## 対象ファイル
+
+| ファイル | 操作 |
+|---------|------|
+| `src/cli.ts` | **新規** — CLI エントリーポイント |
+| `tests/cli.test.ts` | **新規** — ブートストラップ関数のユニットテスト |
+| `tsup.config.ts` | **変更** — entry に `src/cli.ts` を追加 |
+| `package.json` | **変更** — `bin` フィールド追加 |
+
+## `src/cli.ts` の公開関数
+
+```typescript
+/** プロバイダー名からファクトリを選択して生成 */
+export function createProvider(name: string, config: ProviderConfig, model: string): Result<LLMProvider>
+
+/** 組み込みツールを全て登録した ToolRegistry を生成 */
+export function createDefaultToolRegistry(): ToolRegistry
+
+/** RPC メソッドハンドラを構築（AgentLoop と接続） */
+export function createServeHandler(agentLoop: AgentLoop, abortController: AbortController): RpcRequestHandler
+
+/** メインのブートストラップ + RPC サーバー起動 */
+export async function serve(args: { provider?: string; model?: string; persona?: string }): Promise<void>
+```
+
+## TDD 実装順序
+
+1. `tests/cli.test.ts` — `createProvider` テスト（Red）
+2. `src/cli.ts` — `createProvider` 実装（Green）
+3. `tests/cli.test.ts` — `createDefaultToolRegistry` テスト追加（Red）
+4. `src/cli.ts` — `createDefaultToolRegistry` 実装（Green）
+5. `tests/cli.test.ts` — `createServeHandler` テスト追加（Red）
+6. `src/cli.ts` — `createServeHandler` + `serve` + `main` 実装（Green）
+7. `tsup.config.ts` — entry 追加
+8. `package.json` — `bin` フィールド追加
+9. 全検証（typecheck / lint / format / test / build / semgrep）
+
+## テスト戦略
+
+- `createProvider`: 各プロバイダー名で正しいファクトリが呼ばれるか、不明なプロバイダーでエラーになるか
+- `createDefaultToolRegistry`: 4つの組み込みツール（read, write, shell, grep）が全て登録されるか
+- `createServeHandler`: input/abort/configUpdate の各 RPC メソッドが正しく動作するか（AgentLoop はモック）
+
+## 検証手順
+
+```bash
+npm run typecheck
+npm run lint
+npm run format:check
+npm test
+npm run build
+# 動作確認
+node dist/cli.js serve 2>&1
+```

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "wn-core": "dist/cli.js"
+  },
   "scripts": {
     "build": "tsup",
     "dev": "tsx src/index.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+
+/**
+ * wn-core CLI エントリポイント
+ *
+ * serve サブコマンドで JSON-RPC サーバーを起動し、
+ * TUI クライアントからの接続を待ち受ける。
+ */
+import { parseArgs } from 'node:util'
+import os from 'node:os'
+import path from 'node:path'
+import type { Result } from './result.js'
+import { err } from './result.js'
+import type { LLMProvider } from './providers/types.js'
+import type { ProviderConfig } from './loader/types.js'
+import type { RpcRequestHandler } from './rpc/types.js'
+import { createClaudeProvider } from './providers/claude.js'
+import { createOpenAIProvider } from './providers/openai.js'
+import { createOllamaProvider } from './providers/ollama.js'
+import { createGeminiProvider } from './providers/gemini.js'
+import { createReadTool } from './tools/read.js'
+import { createWriteTool } from './tools/write.js'
+import { createShellTool } from './tools/shell.js'
+import { createGrepTool } from './tools/grep.js'
+import { ToolRegistry } from './tools/types.js'
+import { AgentLoop } from './agent/agent-loop.js'
+import {
+  createRpcRequestHandler,
+  createRpcServer,
+  createStdioTransport,
+  createRpcAgentHandler,
+} from './rpc/server.js'
+import { loadConfig } from './loader/config-loader.js'
+import { loadPersonas } from './loader/persona-loader.js'
+import { loadSkills } from './loader/skill-loader.js'
+import { loadAgents } from './loader/agent-loader.js'
+import { createMcpManager } from './mcp/client.js'
+import type { McpManager } from './mcp/types.js'
+
+// ─── createProvider ───
+
+/**
+ * プロバイダー名からファクトリ関数を呼び出し LLMProvider を生成する
+ */
+export function createProvider(
+  name: string,
+  config: ProviderConfig,
+  model: string,
+): Result<LLMProvider> {
+  switch (name) {
+    case 'claude':
+      return createClaudeProvider(config, model)
+    case 'openai':
+      return createOpenAIProvider(config, model)
+    case 'ollama':
+      return createOllamaProvider(config, model)
+    case 'gemini':
+      return createGeminiProvider(config, model)
+    default:
+      return err(`Unknown provider: ${name}`)
+  }
+}
+
+// ─── createDefaultToolRegistry ───
+
+/**
+ * 4つのビルトインツール（read, write, shell, grep）を登録した ToolRegistry を返す
+ */
+export function createDefaultToolRegistry(): ToolRegistry {
+  const registry = new ToolRegistry()
+  registry.register(createReadTool())
+  registry.register(createWriteTool())
+  registry.register(createShellTool())
+  registry.register(createGrepTool())
+  return registry
+}
+
+// ─── createServeHandler ───
+
+/**
+ * AgentLoop と AbortController から RPC リクエストハンドラを生成する
+ *
+ * TUI → Core 方向のリクエスト（input, abort, configUpdate）を処理する。
+ */
+export function createServeHandler(
+  agentLoop: AgentLoop,
+  abortController: AbortController,
+): RpcRequestHandler {
+  return createRpcRequestHandler({
+    async input(params: unknown): Promise<unknown> {
+      const { text } = params as { text: string }
+      const result = await agentLoop.step(text)
+      return { accepted: result.ok }
+    },
+    abort(): Promise<unknown> {
+      abortController.abort()
+      return Promise.resolve({ aborted: true })
+    },
+    configUpdate(): Promise<unknown> {
+      return Promise.resolve({ applied: true })
+    },
+  })
+}
+
+// ─── serve ───
+
+/**
+ * serve サブコマンドの本体
+ *
+ * 設定ロード → プロバイダー生成 → ペルソナ/スキル/エージェント読み込み →
+ * ツールレジストリ構築 → MCP 接続 → AgentLoop + RPC サーバー起動
+ */
+async function serve(args: { provider?: string; model?: string; persona?: string }): Promise<void> {
+  const globalDir = path.join(os.homedir(), '.wn')
+  const localDir = path.join(process.cwd(), '.wn')
+
+  // 1. 設定ロード
+  const configResult = await loadConfig(globalDir, localDir, {
+    ...(args.provider !== undefined ? { defaultProvider: args.provider } : {}),
+    ...(args.model !== undefined ? { defaultModel: args.model } : {}),
+    ...(args.persona !== undefined ? { defaultPersona: args.persona } : {}),
+  })
+  if (!configResult.ok) {
+    console.error(`Failed to load config: ${configResult.error.message}`)
+    process.exit(1)
+  }
+  const config = configResult.data
+
+  // 2. プロバイダー生成
+  const providerConfig = config.providers[config.defaultProvider] ?? {}
+  const providerResult = createProvider(config.defaultProvider, providerConfig, config.defaultModel)
+  if (!providerResult.ok) {
+    console.error(`Failed to create provider: ${providerResult.error}`)
+    process.exit(1)
+  }
+  const provider = providerResult.data
+
+  // 3. ペルソナ / スキル / エージェント 並列読み込み
+  const [personasResult, skillsResult, agentsResult] = await Promise.all([
+    loadPersonas(globalDir, localDir),
+    loadSkills(globalDir, localDir),
+    loadAgents(globalDir, localDir),
+  ])
+
+  if (!personasResult.ok) {
+    console.error(`Failed to load personas: ${personasResult.error.message}`)
+    process.exit(1)
+  }
+  if (!skillsResult.ok) {
+    console.error(`Failed to load skills: ${skillsResult.error.message}`)
+    process.exit(1)
+  }
+  if (!agentsResult.ok) {
+    console.error(`Failed to load agents: ${agentsResult.error.message}`)
+    process.exit(1)
+  }
+
+  const personas = personasResult.data
+
+  // 4. ToolRegistry 構築
+  const toolRegistry = createDefaultToolRegistry()
+
+  // 5. MCP 接続（設定がある場合のみ）
+  let mcpManager: McpManager | undefined
+  if (config.mcp) {
+    mcpManager = createMcpManager(config.mcp)
+    const connectResult = await mcpManager.connectAll()
+    if (connectResult.ok) {
+      for (const conn of connectResult.data) {
+        for (const tool of conn.tools) {
+          toolRegistry.registerMcp(tool)
+        }
+      }
+    } else {
+      console.error(`MCP connection warning: ${connectResult.error}`)
+    }
+  }
+
+  // 6. AbortController
+  const abortController = new AbortController()
+
+  // 7. ペルソナからシステムメッセージを取得
+  const persona = personas.get(config.defaultPersona)
+  const systemMessage = persona?.content
+
+  // 8. RPC トランスポート + サーバー（循環参照回避）
+  const transport = createStdioTransport(process.stdin, process.stdout)
+
+  // agentLoop を後から代入するため配列で間接参照
+  const agentLoopRef: [AgentLoop | undefined] = [undefined]
+
+  // RPC ハンドラは agentLoopRef 経由で AgentLoop を参照する（循環参照回避）
+  const rpcHandler = createRpcRequestHandler({
+    async input(params: unknown): Promise<unknown> {
+      const { text } = params as { text: string }
+      const loop = agentLoopRef[0]
+      if (!loop) {
+        return { accepted: false }
+      }
+      const result = await loop.step(text)
+      return { accepted: result.ok }
+    },
+    abort(): Promise<unknown> {
+      abortController.abort()
+      return Promise.resolve({ aborted: true })
+    },
+    configUpdate(): Promise<unknown> {
+      return Promise.resolve({ applied: true })
+    },
+  })
+
+  const rpcServer = createRpcServer({ transport, handler: rpcHandler })
+
+  // AgentLoop のイベントを RPC 通知としてクライアントに送信する
+  const agentHandler = createRpcAgentHandler(rpcServer)
+
+  agentLoopRef[0] = new AgentLoop({
+    provider,
+    tools: toolRegistry,
+    handler: agentHandler,
+    systemMessage,
+    signal: abortController.signal,
+  })
+
+  // 9. シグナルハンドラ（graceful shutdown）
+  const shutdown = (): void => {
+    console.error('Shutting down...')
+    abortController.abort()
+    rpcServer.stop()
+    if (mcpManager) {
+      void mcpManager.closeAll()
+    }
+  }
+
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+
+  // 10. 起動ログ（stderr に出力 — stdout は JSON-RPC 用）
+  console.error(
+    `wn-core serve started (provider=${config.defaultProvider}, model=${config.defaultModel})`,
+  )
+
+  // 11. RPC サーバー開始（入力ストリームが終了するまでブロック）
+  await rpcServer.start()
+}
+
+// ─── main ───
+
+/**
+ * CLI エントリポイント
+ *
+ * parseArgs でサブコマンドとオプションを解析し、対応する関数を呼び出す。
+ */
+export async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    options: {
+      provider: { type: 'string' },
+      model: { type: 'string' },
+      persona: { type: 'string' },
+    },
+    allowPositionals: true,
+  })
+
+  const subcommand = positionals[0]
+
+  if (subcommand === 'serve') {
+    await serve({
+      provider: values.provider,
+      model: values.model,
+      persona: values.persona,
+    })
+  } else {
+    console.error('Usage: wn-core <command>')
+    console.error('')
+    console.error('Commands:')
+    console.error('  serve   Start the JSON-RPC agent server')
+    console.error('')
+    console.error('Options:')
+    console.error('  --provider <name>   LLM provider (claude, openai, ollama, gemini)')
+    console.error('  --model <name>      Model name')
+    console.error('  --persona <name>    Persona name')
+    process.exit(1)
+  }
+}
+
+// エントリポイントとして直接実行された場合のみ main() を呼ぶ
+// テストからの import 時は実行しない
+import { fileURLToPath } from 'node:url'
+
+const isEntryPoint =
+  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+
+if (isEntryPoint) {
+  void main()
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Result } from '../src/result.js'
+import type { LLMProvider } from '../src/providers/types.js'
+
+// --- Provider ファクトリのモック ---
+
+const mockProvider: LLMProvider = {
+  complete() {
+    return Promise.resolve({ ok: true, data: { content: 'mock', toolCalls: [] } })
+  },
+}
+
+vi.mock('../src/providers/claude.js', () => ({
+  createClaudeProvider: vi.fn((): Result<LLMProvider> => ({ ok: true, data: mockProvider })),
+}))
+
+vi.mock('../src/providers/openai.js', () => ({
+  createOpenAIProvider: vi.fn((): Result<LLMProvider> => ({ ok: true, data: mockProvider })),
+}))
+
+vi.mock('../src/providers/ollama.js', () => ({
+  createOllamaProvider: vi.fn((): Result<LLMProvider> => ({ ok: true, data: mockProvider })),
+}))
+
+vi.mock('../src/providers/gemini.js', () => ({
+  createGeminiProvider: vi.fn((): Result<LLMProvider> => ({ ok: true, data: mockProvider })),
+}))
+
+// テスト対象をインポート（モック定義後）
+import { createProvider, createDefaultToolRegistry, createServeHandler } from '../src/cli.js'
+import { createClaudeProvider } from '../src/providers/claude.js'
+import { createOpenAIProvider } from '../src/providers/openai.js'
+import { createOllamaProvider } from '../src/providers/ollama.js'
+import { createGeminiProvider } from '../src/providers/gemini.js'
+
+// ─── createProvider ───
+
+describe('createProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('claude を指定すると createClaudeProvider を呼ぶ', () => {
+    const config = { apiKey: 'test-key' }
+    const result = createProvider('claude', config, 'claude-sonnet-4-20250514')
+
+    expect(result.ok).toBe(true)
+    expect(createClaudeProvider).toHaveBeenCalledWith(config, 'claude-sonnet-4-20250514')
+  })
+
+  it('openai を指定すると createOpenAIProvider を呼ぶ', () => {
+    const config = { apiKey: 'test-key' }
+    const result = createProvider('openai', config, 'gpt-4o')
+
+    expect(result.ok).toBe(true)
+    expect(createOpenAIProvider).toHaveBeenCalledWith(config, 'gpt-4o')
+  })
+
+  it('ollama を指定すると createOllamaProvider を呼ぶ', () => {
+    const config = {}
+    const result = createProvider('ollama', config, 'llama3')
+
+    expect(result.ok).toBe(true)
+    expect(createOllamaProvider).toHaveBeenCalledWith(config, 'llama3')
+  })
+
+  it('gemini を指定すると createGeminiProvider を呼ぶ', () => {
+    const config = { apiKey: 'test-key' }
+    const result = createProvider('gemini', config, 'gemini-pro')
+
+    expect(result.ok).toBe(true)
+    expect(createGeminiProvider).toHaveBeenCalledWith(config, 'gemini-pro')
+  })
+
+  it('未知のプロバイダー名で err を返す', () => {
+    const result = createProvider('unknown', {}, 'model')
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('Unknown provider')
+      expect(result.error).toContain('unknown')
+    }
+  })
+})
+
+// ─── createDefaultToolRegistry ───
+
+describe('createDefaultToolRegistry', () => {
+  it('4つのビルトインツールを持つ ToolRegistry を返す', () => {
+    const registry = createDefaultToolRegistry()
+    const tools = registry.list()
+
+    expect(tools).toHaveLength(4)
+  })
+
+  it('read ツールが取得できる', () => {
+    const registry = createDefaultToolRegistry()
+    const tool = registry.get('read')
+
+    expect(tool).toBeDefined()
+    expect(tool?.name).toBe('read')
+  })
+
+  it('write ツールが取得できる', () => {
+    const registry = createDefaultToolRegistry()
+    const tool = registry.get('write')
+
+    expect(tool).toBeDefined()
+    expect(tool?.name).toBe('write')
+  })
+
+  it('shell ツールが取得できる', () => {
+    const registry = createDefaultToolRegistry()
+    const tool = registry.get('shell')
+
+    expect(tool).toBeDefined()
+    expect(tool?.name).toBe('shell')
+  })
+
+  it('grep ツールが取得できる', () => {
+    const registry = createDefaultToolRegistry()
+    const tool = registry.get('grep')
+
+    expect(tool).toBeDefined()
+    expect(tool?.name).toBe('grep')
+  })
+})
+
+// ─── createServeHandler ───
+
+describe('createServeHandler', () => {
+  it('input メソッドで agentLoop.step(text) を呼び、 { accepted: boolean } を返す', async () => {
+    const mockStep = vi.fn().mockResolvedValue({ ok: true, data: 'response' })
+    const mockAgentLoop = { step: mockStep } as unknown as Parameters<typeof createServeHandler>[0]
+    const abortController = new AbortController()
+
+    const handler = createServeHandler(mockAgentLoop, abortController)
+    const result = await handler('input', { text: 'hello' })
+
+    expect(mockStep).toHaveBeenCalledWith('hello')
+    expect(result).toEqual({ accepted: true })
+  })
+
+  it('input メソッドで step が失敗した場合 accepted: false を返す', async () => {
+    const mockStep = vi.fn().mockResolvedValue({ ok: false, error: 'fail' })
+    const mockAgentLoop = { step: mockStep } as unknown as Parameters<typeof createServeHandler>[0]
+    const abortController = new AbortController()
+
+    const handler = createServeHandler(mockAgentLoop, abortController)
+    const result = await handler('input', { text: 'hello' })
+
+    expect(result).toEqual({ accepted: false })
+  })
+
+  it('abort メソッドで abortController.abort() を呼び { aborted: true } を返す', async () => {
+    const mockAgentLoop = { step: vi.fn() } as unknown as Parameters<typeof createServeHandler>[0]
+    const abortController = new AbortController()
+    const abortSpy = vi.spyOn(abortController, 'abort')
+
+    const handler = createServeHandler(mockAgentLoop, abortController)
+    const result = await handler('abort', {})
+
+    expect(abortSpy).toHaveBeenCalled()
+    expect(result).toEqual({ aborted: true })
+  })
+
+  it('configUpdate メソッドで { applied: true } を返す', async () => {
+    const mockAgentLoop = { step: vi.fn() } as unknown as Parameters<typeof createServeHandler>[0]
+    const abortController = new AbortController()
+
+    const handler = createServeHandler(mockAgentLoop, abortController)
+    const result = await handler('configUpdate', {})
+
+    expect(result).toEqual({ applied: true })
+  })
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup"
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/agent/sub-agent-worker.ts"],
+  entry: ["src/index.ts", "src/cli.ts", "src/agent/sub-agent-worker.ts"],
   format: ["esm"],
   dts: true,
   target: "node20",


### PR DESCRIPTION
## Summary
- `src/cli.ts`: CLI エントリーポイント実装（parseArgs → config ロード → プロバイダー生成 → ToolRegistry 構築 → MCP 接続 → AgentLoop + RPC サーバー起動）
- `package.json`: `bin: { "wn-core": "dist/cli.js" }` 追加
- `tsup.config.ts`: entry に `src/cli.ts` 追加
- `tests/cli.test.ts`: 14 テスト（createProvider / createDefaultToolRegistry / createServeHandler）
- `docs/plan-cli-entrypoint.md`: 実装計画

## Test plan
- [x] 全 344 テスト通過（リグレッションなし）
- [x] typecheck / lint / format / build / semgrep 全パス
- [ ] `npm run build && node dist/cli.js serve` で RPC サーバー起動確認

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)