### PR TITLE
chore: npm 公開用の package.json 整備

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:fix": "eslint src/ tests/ --fix",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run typecheck && npm run lint && npm test && npm run build"
   },
   "engines": {
     "node": ">=20"
@@ -27,7 +28,22 @@
     "type": "git",
     "url": "git+https://github.com/0x6d61/wn-core.git"
   },
+  "author": "0x6d61",
   "license": "MIT",
+  "keywords": [
+    "ai",
+    "agent",
+    "llm",
+    "json-rpc",
+    "claude",
+    "openai",
+    "ollama",
+    "gemini",
+    "mcp"
+  ],
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.3.0",


### PR DESCRIPTION
## Summary
- `files: ["dist"]` 追加（公開対象を dist/ に制限、69.2 kB）
- `keywords` 追加（ai, agent, llm, json-rpc, claude, openai, ollama, gemini, mcp）
- `author: "0x6d61"` 追加
- `prepublishOnly` スクリプト追加（typecheck → lint → test → build を公開前に自動実行）

## Test plan
- [x] `npm pack --dry-run` で公開対象が dist/ + package.json + LICENSE のみであることを確認
- [x] src/, tests/, docs/ が含まれないことを確認

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)