### PR TITLE
chore: npm パッケージ名を @0x6d61/wn-core に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wn-core",
+  "name": "@0x6d61/wn-core",
   "version": "0.1.0",
   "description": "Lightweight AI Agent Core Framework",
   "type": "module",


### PR DESCRIPTION
## Summary
- `package.json` の name を `wn-core` → `@0x6d61/wn-core` に変更
- npm の typosquatting 対策により `n8n-core` と類似判定されたため、スコープ付き名前を使用

## Test plan
- [ ] `npm publish --access=public --otp=<code>` で公開成功を確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)