### PR TITLE
feat: support Claude OAuth token (authToken) authentication

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -112,6 +112,16 @@ if (result.ok) {
 
 API キーは `${ENV_VAR}` 形式で環境変数を参照できます。
 
+**OAuth トークン (authToken):** Claude プロバイダーは OAuth 認証にも対応しています。Claude OAuth トークンで認証する場合は `apiKey` の代わりに `authToken` を使用してください:
+
+```json
+{
+  "providers": {
+    "claude": { "authToken": "${ANTHROPIC_AUTH_TOKEN}" }
+  }
+}
+```
+
 **優先順位（高 → 低）:** CLI フラグ > プロジェクトローカル `.wn/` > グローバル `~/.wn/`
 
 ## Persona / Skill / Agent

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ Configuration is loaded from two levels: `~/.wn/config.json` (global) and `.wn/c
 
 API keys can reference environment variables using `${ENV_VAR}` syntax.
 
+**OAuth Token (authToken):** Claude provider also supports OAuth authentication via `authToken`. Use `authToken` instead of `apiKey` when authenticating with a Claude OAuth token:
+
+```json
+{
+  "providers": {
+    "claude": { "authToken": "${ANTHROPIC_AUTH_TOKEN}" }
+  }
+}
+```
+
 **Priority (highest to lowest):** CLI flags > project-local `.wn/` > global `~/.wn/`
 
 ## Personas, Skills & Agents

--- a/src/loader/config-loader.ts
+++ b/src/loader/config-loader.ts
@@ -125,6 +125,7 @@ function substituteEnvVars(obj: unknown): unknown {
 function isProviderConfig(value: unknown): value is ProviderConfig {
   if (!isPlainObject(value)) return false
   if ('apiKey' in value && typeof value['apiKey'] !== 'string') return false
+  if ('authToken' in value && typeof value['authToken'] !== 'string') return false
   if ('baseUrl' in value && typeof value['baseUrl'] !== 'string') return false
   return true
 }

--- a/src/loader/types.ts
+++ b/src/loader/types.ts
@@ -13,6 +13,7 @@ export interface McpConfig {
 /** LLM プロバイダー設定 */
 export interface ProviderConfig {
   readonly apiKey?: string
+  readonly authToken?: string
   readonly baseUrl?: string
 }
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -219,17 +219,18 @@ function convertTools(
 /**
  * Claude (Anthropic) LLM プロバイダーを作成する
  *
- * @param config - プロバイダー設定（apiKey 必須）
+ * @param config - プロバイダー設定（apiKey または authToken が必須）
  * @param model - 使用するモデル名（例: 'claude-sonnet-4-20250514'）
  * @returns Result<LLMProvider> - 成功時は LLMProvider、失敗時はエラーメッセージ
  */
 export function createClaudeProvider(config: ProviderConfig, model: string): Result<LLMProvider> {
-  if (!config.apiKey) {
-    return err('Claude provider requires an API key')
+  if (!config.apiKey && !config.authToken) {
+    return err('Claude provider requires an API key or auth token')
   }
 
   const client = new Anthropic({
-    apiKey: config.apiKey,
+    apiKey: config.apiKey ?? null,
+    authToken: config.authToken ?? null,
     ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
   })
 

--- a/tests/providers/claude.test.ts
+++ b/tests/providers/claude.test.ts
@@ -137,18 +137,28 @@ describe('Claude Provider', () => {
 
   // 1. APIキーなし→err
   describe('createClaudeProvider', () => {
-    it('APIキーが設定されていない場合、err を返す', () => {
+    it('apiKey も authToken もない場合はエラーを返す', () => {
       const config: ProviderConfig = {}
       const result = createClaudeProvider(config, 'claude-sonnet-4-20250514')
       expect(result).toStrictEqual({
         ok: false,
-        error: 'Claude provider requires an API key',
+        error: 'Claude provider requires an API key or auth token',
       })
     })
 
     // 2. 正常作成→ok(LLMProvider)
     it('APIキーが設定されている場合、ok(LLMProvider) を返す', () => {
       const config: ProviderConfig = { apiKey: 'sk-ant-test-key' }
+      const result = createClaudeProvider(config, 'claude-sonnet-4-20250514')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toHaveProperty('complete')
+        expect(result.data).toHaveProperty('stream')
+      }
+    })
+
+    it('authToken のみで ok(LLMProvider) を返す', () => {
+      const config: ProviderConfig = { authToken: 'oauth-token-test' }
       const result = createClaudeProvider(config, 'claude-sonnet-4-20250514')
       expect(result.ok).toBe(true)
       if (result.ok) {


### PR DESCRIPTION
## Summary
- Add `authToken` field to `ProviderConfig` for Claude OAuth token authentication
- `createClaudeProvider` now accepts either `apiKey` or `authToken` (at least one required)
- Updated `isProviderConfig` type guard to validate `authToken` field
- Added 4 new tests (348 total): authToken-only provider creation, config loading with authToken, combined apiKey+authToken, invalid authToken type rejection
- Updated both README.md and README.ja.md with OAuth token configuration examples

Closes #37

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 348 tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)