### PR TITLE
fix: authToken認識修正 + 環境変数フォールバック追加

### DIFF
--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -224,13 +224,18 @@ function convertTools(
  * @returns Result<LLMProvider> - 成功時は LLMProvider、失敗時はエラーメッセージ
  */
 export function createClaudeProvider(config: ProviderConfig, model: string): Result<LLMProvider> {
-  if (!config.apiKey && !config.authToken) {
-    return err('Claude provider requires an API key or auth token')
+  const apiKey = config.apiKey ?? process.env['ANTHROPIC_API_KEY']
+  const authToken = config.authToken ?? process.env['ANTHROPIC_AUTH_TOKEN']
+
+  if (!apiKey && !authToken) {
+    return err(
+      'Claude provider requires an API key or auth token. Set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN environment variable, or configure in config.json',
+    )
   }
 
   const client = new Anthropic({
-    apiKey: config.apiKey ?? null,
-    authToken: config.authToken ?? null,
+    ...(apiKey ? { apiKey } : {}),
+    ...(authToken ? { authToken } : {}),
     ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
   })
 

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -198,11 +198,14 @@ function buildRequest(
  * @returns Result<LLMProvider> - 成功時は LLMProvider、失敗時はエラーメッセージ
  */
 export function createGeminiProvider(config: ProviderConfig, model: string): Result<LLMProvider> {
-  if (!config.apiKey) {
-    return err('Gemini provider requires an API key')
+  const apiKey = config.apiKey ?? process.env['GEMINI_API_KEY']
+  if (!apiKey) {
+    return err(
+      'Gemini provider requires an API key. Set GEMINI_API_KEY environment variable, or configure in config.json',
+    )
   }
 
-  const genAI = new GoogleGenerativeAI(config.apiKey)
+  const genAI = new GoogleGenerativeAI(apiKey)
   const generativeModel = genAI.getGenerativeModel({ model })
 
   const provider: LLMProvider = {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -161,12 +161,15 @@ interface ToolCallAccumulator {
  * @returns Result<LLMProvider> - 成功時はプロバイダーインスタンス、失敗時はエラー
  */
 export function createOpenAIProvider(config: ProviderConfig, model: string): Result<LLMProvider> {
-  if (!config.apiKey) {
-    return err('OpenAI provider requires an API key')
+  const apiKey = config.apiKey ?? process.env['OPENAI_API_KEY']
+  if (!apiKey) {
+    return err(
+      'OpenAI provider requires an API key. Set OPENAI_API_KEY environment variable, or configure in config.json',
+    )
   }
 
   const client = new OpenAI({
-    apiKey: config.apiKey,
+    apiKey,
     ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
   })
 


### PR DESCRIPTION
## Summary
- Claude プロバイダーで `apiKey: null` を SDK に渡していたため、`authToken` のみ設定しても認識されない問題を修正
- 全プロバイダー（Claude, OpenAI, Gemini）に環境変数フォールバックを追加し、config.json なしでも起動可能に

### 対応した環境変数
| Provider | 環境変数 |
|----------|---------|
| Claude | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` |
| OpenAI | `OPENAI_API_KEY` |
| Gemini | `GEMINI_API_KEY` |

### 優先順位
config.json の値 > 環境変数 > エラー

## Test plan
- [x] Claude: 環境変数 `ANTHROPIC_AUTH_TOKEN` のみでプロバイダー作成可能
- [x] Claude: 環境変数 `ANTHROPIC_API_KEY` のみでプロバイダー作成可能
- [x] Claude: config の値が環境変数より優先される
- [x] OpenAI: 環境変数フォールバック（3テスト）
- [x] Gemini: 環境変数フォールバック（3テスト）
- [x] 全358テスト通過

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)