### PR TITLE
fix: AgentLoop の maxToolRounds デフォルト制限を撤廃

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -3,8 +3,6 @@ import { ok, err } from '../result.js'
 import type { Message, Tool } from '../providers/types.js'
 import type { AgentLoopHandler, AgentLoopOptions, AgentLoopState } from './types.js'
 
-const DEFAULT_MAX_TOOL_ROUNDS = 10
-
 /**
  * AgentLoop — LLMProvider + ToolRegistry を接続する対話ループ
  *
@@ -25,7 +23,7 @@ export class AgentLoop {
       provider: opts.provider,
       tools: opts.tools,
       handler: opts.handler,
-      maxToolRounds: opts.maxToolRounds ?? DEFAULT_MAX_TOOL_ROUNDS,
+      maxToolRounds: opts.maxToolRounds ?? Infinity,
       signal: opts.signal,
     }
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -92,6 +92,7 @@ export interface AgentLoopOptions {
   readonly tools: ToolRegistry
   readonly handler: AgentLoopHandler
   readonly systemMessage?: string
+  /** ツール呼び出しラウンドの上限。省略時は無制限（Infinity） */
   readonly maxToolRounds?: number
   readonly signal?: AbortSignal
 }

--- a/tests/agent/agent-loop.test.ts
+++ b/tests/agent/agent-loop.test.ts
@@ -87,10 +87,8 @@ describe('AgentLoop', () => {
   // constructor
   // -------------------------------------------------------------------------
   describe('constructor', () => {
-    it('デフォルトの maxToolRounds は 10', () => {
-      // maxToolRounds を指定せずに構築し、10 ラウンド目で打ち切られることを間接検証する。
-      // ここでは内部状態の確認が難しいため、step() で 10 回ツールを返して
-      // エラーになることで検証する（エラー/ガードセクションの test 14 で詳細検証）。
+    it('デフォルトではラウンド制限なし（maxToolRounds 省略時）', () => {
+      // maxToolRounds を指定せずに構築 → デフォルトは Infinity（無制限）。
       // constructor レベルではオプション省略時にエラーにならないことを検証。
       const loop = new AgentLoop({
         provider: mockProvider,


### PR DESCRIPTION
## Summary
- `DEFAULT_MAX_TOOL_ROUNDS = 10` を削除し、デフォルトを `Infinity`（無制限）に変更
- `maxToolRounds` オプション自体は残す（テストや特殊用途で制限したい場合に使える）
- ループの安全装置は `AbortSignal` に一本化

## Test plan
- [x] 全363テスト合格（`npm test`）
- [x] `maxToolRounds: 3` を明示指定した既存テストが引き続き動作

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)