### PR TITLE
fix: MCP 接続の部分失敗警告表示 + env フィールド対応

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,13 +166,16 @@ async function serve(args: { provider?: string; model?: string; persona?: string
     mcpManager = createMcpManager(config.mcp)
     const connectResult = await mcpManager.connectAll()
     if (connectResult.ok) {
-      for (const conn of connectResult.data) {
+      for (const warning of connectResult.data.warnings) {
+        console.error(`MCP connection warning: ${warning}`)
+      }
+      for (const conn of connectResult.data.connections) {
         for (const tool of conn.tools) {
           toolRegistry.registerMcp(tool)
         }
       }
     } else {
-      console.error(`MCP connection warning: ${connectResult.error}`)
+      console.error(`MCP connection error: ${connectResult.error}`)
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export type {
 } from './loader/types.js'
 
 // MCP
-export type { McpConnection, McpManager } from './mcp/types.js'
+export type { McpConnection, McpManager, ConnectAllResult } from './mcp/types.js'
 export { createMcpManager } from './mcp/client.js'
 
 // RPC types

--- a/src/loader/config-loader.ts
+++ b/src/loader/config-loader.ts
@@ -138,7 +138,12 @@ function isMcpServerConfig(value: unknown): value is McpServerConfig {
   if (typeof value['name'] !== 'string') return false
   if (typeof value['command'] !== 'string') return false
   if (!Array.isArray(value['args'])) return false
-  return value['args'].every((a) => typeof a === 'string')
+  if (!value['args'].every((a) => typeof a === 'string')) return false
+  if ('env' in value && value['env'] !== undefined) {
+    if (!isPlainObject(value['env'])) return false
+    if (!Object.values(value['env']).every((v) => typeof v === 'string')) return false
+  }
+  return true
 }
 
 /**

--- a/src/loader/types.ts
+++ b/src/loader/types.ts
@@ -3,6 +3,7 @@ export interface McpServerConfig {
   readonly name: string
   readonly command: string
   readonly args: readonly string[]
+  readonly env?: Readonly<Record<string, string>>
 }
 
 /** MCP 設定 */

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -8,10 +8,16 @@ export interface McpConnection {
   close(): Promise<void>
 }
 
+/** connectAll() の成功結果 */
+export interface ConnectAllResult {
+  readonly connections: readonly McpConnection[]
+  readonly warnings: readonly string[]
+}
+
 /** MCP マネージャー — 複数サーバーの接続を一括管理 */
 export interface McpManager {
   /** 全サーバーに接続し、ツール定義を取得 */
-  connectAll(): Promise<Result<readonly McpConnection[]>>
+  connectAll(): Promise<Result<ConnectAllResult>>
   /** 全接続をクローズ */
   closeAll(): Promise<void>
 }


### PR DESCRIPTION
## Summary

- `connectAll()` の部分失敗時にエラー情報が握りつぶされていた問題を修正。`ConnectAllResult` 型を導入し、成功した接続と警告（`warnings`）を同時に返すようにした
- `McpServerConfig` に `env` フィールドを追加し、`StdioClientTransport` に環境変数を渡せるようにした
- `isMcpServerConfig` バリデーションに `env` の型チェックを追加

## Test plan

- [x] `tests/mcp/client.test.ts` — 部分失敗時に `warnings` が返ることを検証
- [x] `tests/mcp/client.test.ts` — env 付きサーバー接続テスト追加
- [x] `tests/loader/config-loader.test.ts` — env 付き設定読み込み、環境変数置換、不正値拒否、互換性テスト追加
- [x] 全368テスト パス

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)