### PR TITLE
fix: shell テストのタイムアウトを延長

### DIFF
--- a/tests/tools/shell.test.ts
+++ b/tests/tools/shell.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { createShellTool, getShellConfig } from '../../src/tools/shell.js'
 import type { ToolDefinition } from '../../src/tools/types.js'
 
-describe('createShellTool', () => {
+describe('createShellTool', { timeout: 15_000 }, () => {
   it('コマンドを実行して stdout を返す', async () => {
     const tool = createShellTool()
     // Windows (powershell): echo hello -> "hello\r\n"


### PR DESCRIPTION
## Summary
- Windows の PowerShell 起動遅延により `shell.test.ts` がデフォルト 5000ms タイムアウトで失敗する問題を修正
- `describe` ブロックに `{ timeout: 15_000 }` を設定し、15 秒に延長

## Test plan
- [x] `npm test` で全 370 テストがグリーン
- [x] `tests/tools/shell.test.ts` が安定して通ることを確認

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)